### PR TITLE
Fix z-order when clicking 'assemble'

### DIFF
--- a/src/openDLX/gui/command/systemLevel/CommandCreateFrames.java
+++ b/src/openDLX/gui/command/systemLevel/CommandCreateFrames.java
@@ -21,6 +21,7 @@
 package openDLX.gui.command.systemLevel;
 
 import javax.swing.JOptionPane;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.internalframes.factories.InternalFrameFactory;
@@ -29,10 +30,17 @@ public class CommandCreateFrames implements Command
 {
 
     private MainFrame mf;
+    private String[] intFrameOrder;
 
-    public CommandCreateFrames(MainFrame mf)
+    public CommandCreateFrames(MainFrame mf, String[] intFrameOrder)
     {
         this.mf = mf;
+        this.intFrameOrder = intFrameOrder;
+    }
+    
+    public CommandCreateFrames(MainFrame mf)
+    {
+        this(mf, new String[]{});
     }
 
     @Override
@@ -40,7 +48,7 @@ public class CommandCreateFrames implements Command
     {
         try
         {
-            InternalFrameFactory.getInstance().createAllFrames();
+            InternalFrameFactory.getInstance().createAllFrames(intFrameOrder);
         }
         catch (Exception e)
         {

--- a/src/openDLX/gui/command/systemLevel/CommandStartExecuting.java
+++ b/src/openDLX/gui/command/systemLevel/CommandStartExecuting.java
@@ -31,11 +31,18 @@ public class CommandStartExecuting implements Command
 
     private File configFile; //in
     private MainFrame mf;
+    private String[] intFrameOrder;
 
-    public CommandStartExecuting(MainFrame mf, File f)
+    public CommandStartExecuting(MainFrame mf, File f, String[] intFrameOrder)
     {
         this.mf = mf;
         this.configFile = f;
+        this.intFrameOrder = intFrameOrder;
+    }
+    
+    public CommandStartExecuting(MainFrame mf, File f)
+    {
+        this(mf, f, new String[]{});
     }
 
     @Override
@@ -46,7 +53,7 @@ public class CommandStartExecuting implements Command
         c10.execute();
         if (mf.getOpenDLXSim() != null)
         {   //create all executing-frames   
-            CommandCreateFrames c9 = new CommandCreateFrames(mf);
+            CommandCreateFrames c9 = new CommandCreateFrames(mf, intFrameOrder);
             c9.execute();
         }
         else

--- a/src/openDLX/gui/command/userLevel/CommandRunFromEditor.java
+++ b/src/openDLX/gui/command/userLevel/CommandRunFromEditor.java
@@ -21,6 +21,9 @@
 package openDLX.gui.command.userLevel;
 
 import java.io.File;
+
+import javax.swing.JInternalFrame;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.command.systemLevel.CommandCompileCode;
@@ -63,6 +66,10 @@ public class CommandRunFromEditor implements Command
                 CommandCompileCode c8 = new CommandCompileCode(mf, tmpFile);
                 c8.execute();
                 File configFile = c8.getConfigFile();
+                JInternalFrame[] intFrames = mf.getinternalFrames();
+                String[] intFrameOrder = new String[intFrames.length];
+                for (int i = 0; i < intFrames.length; ++i)
+                    intFrameOrder[i] = intFrames[i].getTitle();
 
                 if (configFile != null)
                 //reset simulator before loading new content
@@ -72,7 +79,7 @@ public class CommandRunFromEditor implements Command
 
 
                     //initialize openDLX and create internal frames, set status to executing
-                    CommandStartExecuting c7 = new CommandStartExecuting(mf, configFile);
+                    CommandStartExecuting c7 = new CommandStartExecuting(mf, configFile, intFrameOrder);
                     c7.execute();
                 }
 

--- a/src/openDLX/gui/internalframes/factories/InternalFrameFactory.java
+++ b/src/openDLX/gui/internalframes/factories/InternalFrameFactory.java
@@ -20,16 +20,18 @@
  ******************************************************************************/
 package openDLX.gui.internalframes.factories;
 
+import java.util.ArrayList;
 import java.util.Hashtable;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.systemLevel.CommandLoadFrameConfigurationSysLevel;
 import openDLX.gui.internalframes.concreteframes.ClockCycleFrame;
 import openDLX.gui.internalframes.concreteframes.CodeFrame;
-import openDLX.gui.internalframes.concreteframes.editor.EditorFrame;
 import openDLX.gui.internalframes.concreteframes.LogFrame;
 import openDLX.gui.internalframes.concreteframes.MemoryFrame;
 import openDLX.gui.internalframes.concreteframes.RegisterFrame;
 import openDLX.gui.internalframes.concreteframes.StatisticsFrame;
+import openDLX.gui.internalframes.concreteframes.editor.EditorFrame;
 
 public class InternalFrameFactory
 {
@@ -65,14 +67,35 @@ public class InternalFrameFactory
         mf = MainFrame.getInstance();
     }
 
-    public void createAllFrames()
+    public void createAllFrames(){
+        createAllFrames(new String[]{});
+    }
+
+    public void createAllFrames(String[] intFrameOrder)
     {
-        createRegisterFrame();
-        createCodeFrame();
-        createLogFrame();
-        createStatisticsFrame();
-        createMemoryFrame(mf);
-        createClockCycleFrame();
+        ArrayList<String> frameOrder = new ArrayList<>(frameNames.size());
+        for (String s : intFrameOrder)
+            frameOrder.add(s);
+        for (String s : frameNames.values())
+            if (!frameOrder.contains(s))
+                frameOrder.add(s);
+
+        for (String s : frameOrder)
+        {
+            if (s.equals("register set"))
+                createRegisterFrame();
+            else if (s.equals("code"))
+                createCodeFrame();
+            else if (s.equals("log"))
+                createLogFrame();
+            else if (s.equals("statistics"))
+                createStatisticsFrame();
+            else if (s.equals("memory"))
+                createMemoryFrame(mf);
+            else if (s.equals("cycles and pipeline"))
+                createClockCycleFrame();
+        }
+
         CommandLoadFrameConfigurationSysLevel c10 = new CommandLoadFrameConfigurationSysLevel(mf);
         c10.execute();
     }
@@ -86,41 +109,35 @@ public class InternalFrameFactory
     {
         MemoryFrame f = new MemoryFrame(frameNames.get(MemoryFrame.class).toString(),mf);
         this.mf.addInternalFrame(f);
-        f.moveToFront();
     }
 
     private void createRegisterFrame()
     {
         RegisterFrame rf = new RegisterFrame(frameNames.get(RegisterFrame.class).toString());
         mf.addInternalFrame(rf);
-        rf.moveToFront();
     }
 
     private void createCodeFrame()
     {
         CodeFrame cf = new CodeFrame(frameNames.get(CodeFrame.class).toString());
         mf.addInternalFrame(cf);
-        cf.moveToFront();
     }
 
     private void createStatisticsFrame()
     {
         StatisticsFrame sf = new StatisticsFrame(frameNames.get(StatisticsFrame.class).toString());
         mf.addInternalFrame(sf);
-        sf.moveToFront();
     }
 
     private void createLogFrame()
     {
         LogFrame lf = new LogFrame(frameNames.get(LogFrame.class).toString());
         mf.addInternalFrame(lf);
-        lf.moveToFront();
     }
      private void createClockCycleFrame()
     {
         ClockCycleFrame ccf = new ClockCycleFrame(frameNames.get(ClockCycleFrame.class).toString());
         mf.addInternalFrame(ccf);
-        ccf.moveToFront();
     }
 
 


### PR DESCRIPTION
Fix a bug where the internal frames would be pushed to the foreground when
clicking the "assemble" button -- most importantly, they would be pushed in
front of the code editor, which is not re-created at this point.

The re-creation of the correct window order is somewhat dirty, since mapping the frames' names to the factory methods requires a large if-else construct.

A more elegant solution (in the absence of function pointers in Java) would be subclasses for the factor (be they descendant classes or just some inner classes) -- but the question is if this would improve readability or actually just make it even less performant (more class overhead, etc).
