### PR TITLE
Feature/improve code readability

### DIFF
--- a/src/openDLX/gui/MainFrame.java
+++ b/src/openDLX/gui/MainFrame.java
@@ -56,10 +56,15 @@ import openDLX.util.TrapObservableDefault;
 @SuppressWarnings("serial")
 public class MainFrame extends JFrame implements ActionListener, ItemListener
 {
-
-    public final int RUN_SPEED_DEFAULT = 16;
-    // MainFrame is a Singleton. 
+    public static final int RUN_SPEED_DEFAULT = 16;
+    
+    // MainFrame is a Singleton.
+    // hence it has a private constructor    
     private static final MainFrame mf = new MainFrame();
+
+    public Output output;
+    public Input input;
+    public CheckBoxList boxes = CheckBoxList.getInstance();
     private OpenDLXSimulator openDLXSim = null;
     private EditorFrame editor;
     private JDesktopPane desktop;
@@ -70,20 +75,15 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
     private File configFile;
     private JMenuBar menuBar;
     private PipelineExceptionHandler pexHandler = null;
-    public Output output;
-    public Input input;
-    public CheckBoxList boxes = CheckBoxList.getInstance();
     private String loadedCodeFilePath="code.s";//default
-    //hence it has a private constructor    
 
     private MainFrame()
     {
         initialize();
-		final ImageIcon icon = new ImageIcon(getClass().getResource("/img/openDLX-quadrat128x128.png"), "openDLX icon");
-		setIconImage(icon.getImage());
+        final ImageIcon icon = new ImageIcon(getClass().getResource("/img/openDLX-quadrat128x128.png"), "openDLX icon");
+        setIconImage(icon.getImage());
 
         setTitle("openDLX " + GlobalConfig.VERSION);
-        
 
         // Register output for pipeline
         TrapObservableDefault observableOutput = new TrapObservableDefault();
@@ -118,7 +118,6 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
 
     private void initialize()
     {
-
         //uses a factory to outsource creation of the menuBar 
         MainFrameMenuBarFactory menuBarFactory = new MainFrameMenuBarFactory(this, this, this);
         menuBar = menuBarFactory.createJMenuBar();
@@ -127,14 +126,21 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
         desktop = new JDesktopPane();
         desktop.setBackground(Color.WHITE);
         setContentPane(desktop);
+        
         editor = EditorFrame.getInstance(this);
         desktop.add(editor);
+        
         //set Editor checkbox in main menu selected as editor is visible
         boxes.get(InternalFrameFactory.getFrameName(EditorFrame.class)).setSelected(true);
+        
         output = Output.getInstance(mf);
         input = Input.getInstance(mf);
+
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setMinimumSize(new Dimension(200, 200));
         setExtendedState(MAXIMIZED_BOTH);
         setVisible(true);
+        
         setOpenDLXSimState(OpenDLXSimState.IDLE);
         pexHandler = new PipelineExceptionHandler(this);
         
@@ -168,7 +174,6 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
     {
         this.openDLXSim = openDLXSim;
         pexHandler.setSimulator(openDLXSim);
-
     }
 
     public void setOpenDLXSimState(OpenDLXSimState s)
@@ -185,29 +190,17 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
 
     public boolean isRunning()
     {
-        if (state == OpenDLXSimState.RUNNING)
-        {
-            return true;
-        }
-        return false;
+        return (state == OpenDLXSimState.RUNNING);
     }
 
     public boolean isExecuting()
     {
-        if (state == OpenDLXSimState.EXECUTING)
-        {
-            return true;
-        }
-        return false;
+        return (state == OpenDLXSimState.EXECUTING);
     }
 
     public boolean isLazy()
     {
-        if (state == OpenDLXSimState.IDLE)
-        {
-            return true;
-        }
-        return false;
+        return (state == OpenDLXSimState.IDLE);
     }
 
     public boolean isUpdateAllowed()
@@ -223,7 +216,6 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
     public void addInternalFrame(OpenDLXSimInternalFrame mif)
     {
         desktop.add(mif);
-
     }
 
     public String getEditorText()

--- a/src/openDLX/gui/OpenDLXSimGui.java
+++ b/src/openDLX/gui/OpenDLXSimGui.java
@@ -29,7 +29,7 @@ import openDLX.gui.LookAndFeel.LookAndFeelStrategySystemMonoSpaced;
 public class OpenDLXSimGui
 {
 
-    static final public String preferenceKey = "lookandfeel";    
+    public static final String preferenceKey = "lookandfeel";
 
     public static void openDLXGui_main()
     {
@@ -37,20 +37,14 @@ public class OpenDLXSimGui
         String lookAndFeel = LookAndFeelStrategySystemMonoSpaced.class.toString();
         //get user preference
         lookAndFeel = Preference.pref.get(preferenceKey, lookAndFeel);
-        //find fitting LaF
-        if (LookAndFeelStrategySystemMonoSpaced.class.toString().equals(lookAndFeel))
-        {
-            new LookAndFeelStrategySystemMonoSpaced().setLookAndFeel();
-            
-        }
-        else if (LookAndFeelStrategyJava.class.toString().equals(lookAndFeel))
-        {
-            new LookAndFeelStrategyJava().setLookAndFeel();
-        }
 
+        //find and set selected LaF
+        if (LookAndFeelStrategySystemMonoSpaced.class.toString().equals(lookAndFeel))
+            new LookAndFeelStrategySystemMonoSpaced().setLookAndFeel();
+        else if (LookAndFeelStrategyJava.class.toString().equals(lookAndFeel))
+            new LookAndFeelStrategyJava().setLookAndFeel();
 
         MainFrame.getInstance();
-
     }
 
     //set look and feel for the whole program

--- a/src/openDLX/gui/command/systemLevel/CommandLoadFrameConfigurationSysLevel.java
+++ b/src/openDLX/gui/command/systemLevel/CommandLoadFrameConfigurationSysLevel.java
@@ -40,16 +40,12 @@ public class CommandLoadFrameConfigurationSysLevel implements Command
     @Override
     public void execute()
     {
-        JInternalFrame internalFrames[] = mf.getinternalFrames();
-        for (int i = 0; i < internalFrames.length; ++i)
+        for (JInternalFrame internalFrame : mf.getinternalFrames())
         {
-            FrameConfiguration fc = new FrameConfiguration(internalFrames[i]);
-            fc.loadFrameConfiguration();
-            JCheckBoxMenuItem item = mf.boxes.get(internalFrames[i].getTitle());
+            new FrameConfiguration(internalFrame).loadFrameConfiguration();
+            JCheckBoxMenuItem item = mf.boxes.get(internalFrame.getTitle());
             if (item != null)
-            {
-                item.setSelected(internalFrames[i].isVisible());
-            }
+                item.setSelected(internalFrame.isVisible());
         }
     }
 

--- a/src/openDLX/gui/command/systemLevel/CommandResetSimulator.java
+++ b/src/openDLX/gui/command/systemLevel/CommandResetSimulator.java
@@ -49,18 +49,16 @@ public class CommandResetSimulator implements Command
             mf.setPause(false);
             mf.setRunSpeed(mf.RUN_SPEED_DEFAULT);
             mf.output.clear();
-            JInternalFrame jif[] = mf.getinternalFrames();
 
-            for (int i = 0; i < jif.length; ++i)
+            for (JInternalFrame jif : mf.getinternalFrames())
             {
-                if (jif[i] instanceof OpenDLXSimInternalFrame)
+                if (jif instanceof OpenDLXSimInternalFrame)
                 {
-                    ((OpenDLXSimInternalFrame) jif[i]).clean();
+                    ((OpenDLXSimInternalFrame) jif).clean();
                 }
             }
             
             Statistics.getInstance().reset();
-
 
         }
         catch (Exception e)

--- a/src/openDLX/gui/command/systemLevel/CommandResetSimulator.java
+++ b/src/openDLX/gui/command/systemLevel/CommandResetSimulator.java
@@ -47,19 +47,14 @@ public class CommandResetSimulator implements Command
             mf.setUpdateAllowed(true);
             mf.setConfigFile(null);
             mf.setPause(false);
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT);
             mf.output.clear();
 
             for (JInternalFrame jif : mf.getinternalFrames())
-            {
                 if (jif instanceof OpenDLXSimInternalFrame)
-                {
                     ((OpenDLXSimInternalFrame) jif).clean();
-                }
-            }
-            
-            Statistics.getInstance().reset();
 
+            Statistics.getInstance().reset();
         }
         catch (Exception e)
         {

--- a/src/openDLX/gui/command/systemLevel/CommandSaveFrameConfigurationSysLevel.java
+++ b/src/openDLX/gui/command/systemLevel/CommandSaveFrameConfigurationSysLevel.java
@@ -39,15 +39,8 @@ public class CommandSaveFrameConfigurationSysLevel implements Command
     @Override
     public void execute()
     {
-
-        JInternalFrame jif[] = mf.getinternalFrames();
-        for (int i = 0; i < jif.length; ++i)
-        {
-            FrameConfiguration fc = new FrameConfiguration(jif[i]);
-            fc.saveFrameConfiguration();
-        }
-
-
+        for (JInternalFrame internalFrame: mf.getinternalFrames())
+            new FrameConfiguration(internalFrame).saveFrameConfiguration();
     }
 
 }

--- a/src/openDLX/gui/command/systemLevel/CommandStartExecuting.java
+++ b/src/openDLX/gui/command/systemLevel/CommandStartExecuting.java
@@ -50,12 +50,10 @@ public class CommandStartExecuting implements Command
     public void execute()
     {
         // call the openDLX constructor and assign a configFile to the new openDLX
-        CommandCreateOpenDLXSim c10 = new CommandCreateOpenDLXSim(mf, configFile);
-        c10.execute();
+        new CommandCreateOpenDLXSim(mf, configFile).execute();
         if (mf.getOpenDLXSim() != null)
         {   //create all executing-frames   
-            CommandCreateFrames c9 = new CommandCreateFrames(mf, intFrameOrder);
-            c9.execute();
+            new CommandCreateFrames(mf, intFrameOrder).execute();
         }
         else
         {

--- a/src/openDLX/gui/command/systemLevel/CommandUpdateFrames.java
+++ b/src/openDLX/gui/command/systemLevel/CommandUpdateFrames.java
@@ -42,14 +42,12 @@ public class CommandUpdateFrames implements Command
     {
         try
         {
-            JInternalFrame jif[] = mf.getinternalFrames();
-
-            for (int i = 0; i < jif.length; ++i)
+            for (JInternalFrame internalFrame : mf.getinternalFrames())
             {
-                if (jif[i] instanceof OpenDLXSimInternalFrame)
+                if (internalFrame instanceof OpenDLXSimInternalFrame)
                 {
-                    ((OpenDLXSimInternalFrame) jif[i]).update();
-                    ((OpenDLXSimInternalFrame) jif[i]).repaint();
+                    ((OpenDLXSimInternalFrame) internalFrame).update();
+                    ((OpenDLXSimInternalFrame) internalFrame).repaint();
                 }
             }
         }

--- a/src/openDLX/gui/command/systemLevel/ThreadCommandRun.java
+++ b/src/openDLX/gui/command/systemLevel/ThreadCommandRun.java
@@ -68,10 +68,8 @@ public class ThreadCommandRun implements Runnable
                 public void run()
                 {
                     //update frames when loop is finished or paused (isRunning is set to false by event dispatch thread/user)
-                    CommandUpdateFrames c10 = new CommandUpdateFrames(mf);
-                    c10.execute();
+                    new CommandUpdateFrames(mf).execute();
                 }
-
             });
         }
         catch (Exception e)
@@ -83,8 +81,7 @@ public class ThreadCommandRun implements Runnable
         if (openDLXSim.isFinished())
         { // if the current openDLX has finished, dont allow any gui updates any more                
             mf.setUpdateAllowed(false);
-            CommandSimulatorFinishedInfo c3 = new CommandSimulatorFinishedInfo();
-            c3.execute();
+            new CommandSimulatorFinishedInfo().execute();
         }
     }
 

--- a/src/openDLX/gui/command/systemLevel/ThreadCommandRunSlowly.java
+++ b/src/openDLX/gui/command/systemLevel/ThreadCommandRunSlowly.java
@@ -53,10 +53,9 @@ public class ThreadCommandRunSlowly implements Runnable
                 {
                     Thread.sleep(100);
                 }
-                catch (Exception e)
-                {
-                }
+                catch (Exception e) {}
             }
+
             // do a cycle within openDLX
             try
             {

--- a/src/openDLX/gui/command/userLevel/CommandChangeMemory.java
+++ b/src/openDLX/gui/command/userLevel/CommandChangeMemory.java
@@ -22,12 +22,13 @@
 package openDLX.gui.command.userLevel;
 
 import javax.swing.JOptionPane;
+
+import openDLX.OpenDLXSimulator;
 import openDLX.datatypes.uint32;
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.command.systemLevel.CommandUpdateFrames;
 import openDLX.gui.internalframes.util.ValueInput;
-import openDLX.OpenDLXSimulator;
 
 public class CommandChangeMemory implements Command
 {
@@ -41,13 +42,12 @@ public class CommandChangeMemory implements Command
         this.address = address;
         this.mf = MainFrame.getInstance();
         openDLXSim = mf.getOpenDLXSim();
-
     }
 
     @Override
     public void execute()
     {
-        if (MainFrame.getInstance().isExecuting())
+        if (mf.isExecuting())
         {
             try
             {
@@ -55,8 +55,7 @@ public class CommandChangeMemory implements Command
                 if (value != null)
                 {
                     openDLXSim.getPipeline().getMainMemory().write_u32(address, new uint32(value));
-                    CommandUpdateFrames c = new CommandUpdateFrames(mf);
-                    c.execute();
+                    new CommandUpdateFrames(mf).execute();
                 }
             }
             catch (NumberFormatException e)

--- a/src/openDLX/gui/command/userLevel/CommandChangeRegister.java
+++ b/src/openDLX/gui/command/userLevel/CommandChangeRegister.java
@@ -22,33 +22,33 @@
 package openDLX.gui.command.userLevel;
 
 import javax.swing.JOptionPane;
+
+import openDLX.OpenDLXSimulator;
 import openDLX.datatypes.uint32;
 import openDLX.datatypes.uint8;
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.command.systemLevel.CommandUpdateFrames;
 import openDLX.gui.internalframes.util.ValueInput;
-import openDLX.OpenDLXSimulator;
 
 public class CommandChangeRegister implements Command
 {
 
-    int row; //in
-    MainFrame mf;
-    OpenDLXSimulator openDLXSim;
+    private int row; //in
+    private MainFrame mf;
+    private OpenDLXSimulator openDLXSim;
 
     public CommandChangeRegister(int row)
     {
         this.row = row;
         this.mf = MainFrame.getInstance();
         openDLXSim = mf.getOpenDLXSim();
-
     }
 
     @Override
     public void execute()
     {
-        if (MainFrame.getInstance().isExecuting())
+        if (mf.isExecuting())
         {
             try
             {
@@ -56,8 +56,7 @@ public class CommandChangeRegister implements Command
                 if (value != null)
                 {
                     openDLXSim.getPipeline().getRegisterSet().write(new uint8(row), new uint32(value));
-                    CommandUpdateFrames c = new CommandUpdateFrames(mf);
-                    c.execute();
+                    new CommandUpdateFrames(mf).execute();
                 }
             }
             catch (NumberFormatException e)

--- a/src/openDLX/gui/command/userLevel/CommandChangeWindowVisibility.java
+++ b/src/openDLX/gui/command/userLevel/CommandChangeWindowVisibility.java
@@ -23,6 +23,7 @@ package openDLX.gui.command.userLevel;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JInternalFrame;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 
@@ -41,23 +42,13 @@ public class CommandChangeWindowVisibility implements Command
     @Override
     public void execute()
     {
-        JInternalFrame jif[] = mf.getinternalFrames();
-        for (int i = 0; i < jif.length; ++i)
+        for (JInternalFrame internalFrame : mf.getinternalFrames())
         {
-            if (jif[i].getTitle().equals(box.getName()))
+            if (internalFrame.getTitle().equals(box.getName()))
             {
-                JInternalFrame f = jif[i];
-                if (!box.isSelected())
-                {
-                    f.setVisible(false);
-                }
-                if (box.isSelected())
-                {
-                    f.setVisible(true);
-                }
+                internalFrame.setVisible(box.isSelected());
                 /* // if users closes or opens frame - should it be a preference automatically ?
-                 FrameConfiguration fc = new FrameConfiguration(jif[i]);
-                 fc.saveFrameConfiguration();*/
+                 new FrameConfiguration(internalFrame).saveFrameConfiguration();*/
             }
         }
     }

--- a/src/openDLX/gui/command/userLevel/CommandClearAllPreferences.java
+++ b/src/openDLX/gui/command/userLevel/CommandClearAllPreferences.java
@@ -22,7 +22,9 @@
 package openDLX.gui.command.userLevel;
 
 import java.util.prefs.BackingStoreException;
+
 import javax.swing.JOptionPane;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.Preference;
 import openDLX.gui.command.Command;
@@ -33,7 +35,9 @@ public class CommandClearAllPreferences implements Command
     @Override
     public void execute()
     {
-        if (JOptionPane.showConfirmDialog(MainFrame.getInstance(), "All preferences will be deleted - confirm ?") == JOptionPane.OK_OPTION)
+        if (JOptionPane.showConfirmDialog(MainFrame.getInstance(),
+                "All preferences will be deleted - confirm ?") ==
+                JOptionPane.OK_OPTION)
         {
             try
             {
@@ -41,7 +45,8 @@ public class CommandClearAllPreferences implements Command
             }
             catch (BackingStoreException ex)
             {
-                JOptionPane.showMessageDialog(MainFrame.getInstance(), "Clearing all preferences failed");
+                JOptionPane.showMessageDialog(MainFrame.getInstance(),
+                        "Clearing all preferences failed");
                 System.err.println(ex);
                 ex.printStackTrace();
             }

--- a/src/openDLX/gui/command/userLevel/CommandClearEditor.java
+++ b/src/openDLX/gui/command/userLevel/CommandClearEditor.java
@@ -22,6 +22,7 @@
 package openDLX.gui.command.userLevel;
 
 import javax.swing.JOptionPane;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 
@@ -31,15 +32,12 @@ public class CommandClearEditor implements Command
     @Override
     public void execute()
     {
-
-
         MainFrame mf = MainFrame.getInstance();
-        if (!mf.isRunning())
+        if (!mf.isRunning() && JOptionPane.showConfirmDialog(mf,
+                "Confirm to clear. All code in the editor will be deleted.") ==
+                JOptionPane.OK_OPTION)
         {
-            if (JOptionPane.showConfirmDialog(mf, "Confirm to clear. All written code will be deleted.") == JOptionPane.OK_OPTION)
-            {
-                mf.setEditorText("");
-            }
+            mf.setEditorText("");
         }
     }
 

--- a/src/openDLX/gui/command/userLevel/CommandDisplayTooltips.java
+++ b/src/openDLX/gui/command/userLevel/CommandDisplayTooltips.java
@@ -28,15 +28,10 @@ import openDLX.gui.menubar.OpenDLXSimCheckBoxMenuItem;
 public class CommandDisplayTooltips implements Command
 {
 
-    private static boolean tooltipsEnabled;
-    public final static String preferenceKey = "tooltipsenabled";
-    private OpenDLXSimCheckBoxMenuItem item;
+    public static final String preferenceKey = "tooltipsenabled";
+    private static boolean tooltipsEnabled = Preference.pref.getBoolean(preferenceKey, true);
 
-    static
-    {
-        //get saved preference, default -> tooltipsenabled = true
-        tooltipsEnabled = Preference.pref.getBoolean(preferenceKey, true);
-    }
+    private OpenDLXSimCheckBoxMenuItem item;
 
     public CommandDisplayTooltips(OpenDLXSimCheckBoxMenuItem item)
     {
@@ -50,7 +45,6 @@ public class CommandDisplayTooltips implements Command
 
     public static void setTooltipsEnabled(boolean tooltipsEnabled)
     {
-
         CommandDisplayTooltips.tooltipsEnabled = tooltipsEnabled;
         //save new preference
         Preference.pref.putBoolean(preferenceKey, tooltipsEnabled);

--- a/src/openDLX/gui/command/userLevel/CommandDoCycle.java
+++ b/src/openDLX/gui/command/userLevel/CommandDoCycle.java
@@ -56,17 +56,14 @@ public class CommandDoCycle implements Command
 
             if (!openDLXSim.isFinished())
             {
-                CommandUpdateFrames c10 = new CommandUpdateFrames(mf);
-                c10.execute();
+                new CommandUpdateFrames(mf).execute();
             }
             else
             {
                 mf.setUpdateAllowed(false);
-                CommandSimulatorFinishedInfo c3 = new CommandSimulatorFinishedInfo();
-                c3.execute();
+                new CommandSimulatorFinishedInfo().execute();
             }
         }
-
 
     }
 

--- a/src/openDLX/gui/command/userLevel/CommandDoXCycles.java
+++ b/src/openDLX/gui/command/userLevel/CommandDoXCycles.java
@@ -81,14 +81,12 @@ public class CommandDoXCycles implements Command
                         }
 
                     }
-                    CommandUpdateFrames c10 = new CommandUpdateFrames(mf);
-                    c10.execute();
+                    new CommandUpdateFrames(mf).execute();
 
                     if (openDLXSim.isFinished())
                     { // if the current openDLX has finished, dont allow any gui updates any more                
                         mf.setUpdateAllowed(false);
-                        CommandSimulatorFinishedInfo c3 = new CommandSimulatorFinishedInfo();
-                        c3.execute();
+                        new CommandSimulatorFinishedInfo().execute();
                     }
                 }
             }

--- a/src/openDLX/gui/command/userLevel/CommandExitProgram.java
+++ b/src/openDLX/gui/command/userLevel/CommandExitProgram.java
@@ -22,8 +22,10 @@
 package openDLX.gui.command.userLevel;
 
 import java.util.prefs.BackingStoreException;
+
 import javax.swing.JCheckBox;
 import javax.swing.JOptionPane;
+
 import openDLX.config.GlobalConfig;
 import openDLX.gui.MainFrame;
 import openDLX.gui.Preference;
@@ -40,54 +42,53 @@ public class CommandExitProgram implements Command
     {
         this.mf = mf;
     }
-    
+
     @Override
     public void execute()
     {
-    	if(close())
-    	{
-    		System.exit(0);
-    	}
+        if (close())
+        {
+            System.exit(0);
+        }
     }
-    
+
     public boolean close()
     {
-    	if(Preference.pref.getBoolean(Preference.showExitMessage, true))
-    	{
-    		String exit_message = "Are you sure you want to exit?";
-    		JCheckBox exit_checkbox = new JCheckBox("Do not show this message again.");
-    		Object content[] = {exit_message, exit_checkbox};
-    		int result = JOptionPane.showConfirmDialog(
-    				mf,
-    				content,
-    				"Exit openDLX "+ GlobalConfig.VERSION,
-    				JOptionPane.YES_NO_OPTION);
-    		
-    		if (result != JOptionPane.YES_OPTION)
-    		{
-    			return false;
-    		}
-    		
-    		Preference.pref.putBoolean(Preference.showExitMessage, !exit_checkbox.isSelected());
-    	}
+        if (Preference.pref.getBoolean(Preference.showExitMessage, true))
+        {
+            final String exit_message = "Are you sure you want to exit?";
+            final JCheckBox exit_checkbox = new JCheckBox("Do not show this message again.");
+            final Object content[] = {exit_message, exit_checkbox};
+            final int result = JOptionPane.showConfirmDialog(
+                    mf,
+                    content,
+                    "Exit openDLX "+ GlobalConfig.VERSION,
+                    JOptionPane.YES_NO_OPTION);
 
-    	try
-		{
-    		// push preferences to persistent store
-			Preference.pref.flush();
-		} catch (BackingStoreException e)
-		{
-			System.err.println("Could not save preferences.");
-			e.printStackTrace();
-		}
+            if (result != JOptionPane.YES_OPTION)
+            {
+                return false;
+            }
 
-    	// delete temporary files
-    	TmpFileCleaner.cleanUp();
+            Preference.pref.putBoolean(Preference.showExitMessage, !exit_checkbox.isSelected());
+        }
 
-    	//save current window position
-    	CommandSaveFrameConfigurationSysLevel c11 = new CommandSaveFrameConfigurationSysLevel(mf);
-    	c11.execute();
+        try
+        {
+            // push preferences to persistent store
+            Preference.pref.flush();
+        } catch (BackingStoreException e)
+        {
+            System.err.println("Could not save preferences.");
+            e.printStackTrace();
+        }
 
-    	return true;
+        // delete temporary files
+        TmpFileCleaner.cleanUp();
+
+        //save current window position
+        new CommandSaveFrameConfigurationSysLevel(mf).execute();
+
+        return true;
     }
 }

--- a/src/openDLX/gui/command/userLevel/CommandLoadAndRunFile.java
+++ b/src/openDLX/gui/command/userLevel/CommandLoadAndRunFile.java
@@ -22,13 +22,14 @@
 package openDLX.gui.command.userLevel;
 
 import java.io.File;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.command.systemLevel.CommandCompileCode;
-import openDLX.gui.command.systemLevel.CommandOpenCodeFile;
-import openDLX.gui.command.systemLevel.CommandSaveFrameConfigurationSysLevel;
 import openDLX.gui.command.systemLevel.CommandLoadCodeFileToEditor;
+import openDLX.gui.command.systemLevel.CommandOpenCodeFile;
 import openDLX.gui.command.systemLevel.CommandResetSimulator;
+import openDLX.gui.command.systemLevel.CommandSaveFrameConfigurationSysLevel;
 import openDLX.gui.command.systemLevel.CommandStartExecuting;
 
 public class CommandLoadAndRunFile implements Command
@@ -47,37 +48,33 @@ public class CommandLoadAndRunFile implements Command
         if (!mf.isRunning())
         {
             //save current window position
-            CommandSaveFrameConfigurationSysLevel c11 = new CommandSaveFrameConfigurationSysLevel(mf);
-            c11.execute();
+            new CommandSaveFrameConfigurationSysLevel(mf).execute();
             //show filechooser dialog and choose file
             CommandOpenCodeFile c10 = new CommandOpenCodeFile(mf);
             c10.execute();
             //get chosen file
             File f = c10.getCodeFile();
 
-
             //file is null if user canceled filechooser dialog
             if (f != null)
             {
                 //reset simulator before loading new content
-                CommandResetSimulator cr = new CommandResetSimulator(mf);
-                cr.execute();
+                new CommandResetSimulator(mf).execute();
 
                 //put code into editorFrame
-                CommandLoadCodeFileToEditor c9 = new CommandLoadCodeFileToEditor(mf, f, true);
-                c9.execute();
+                new CommandLoadCodeFileToEditor(mf, f, true).execute();
                 mf.setLoadedCodeFilePath(f.getAbsolutePath());
                 //compile/assemble code with asm package
                 CommandCompileCode c8 = new CommandCompileCode(mf, f);
                 c8.execute();
                 //get result = config file
                 File configFile = c8.getConfigFile();
+
                 //check if assembly was successfull
                 if (configFile != null)
                 {
                     //initialize openDLX and create internal frames, set status to executing
-                    CommandStartExecuting c7 = new CommandStartExecuting(mf, configFile);
-                    c7.execute();
+                    new CommandStartExecuting(mf, configFile).execute();
                 }
             }
 

--- a/src/openDLX/gui/command/userLevel/CommandLoadFile.java
+++ b/src/openDLX/gui/command/userLevel/CommandLoadFile.java
@@ -51,8 +51,7 @@ public class CommandLoadFile implements Command
             {
                 if (f != null)
                 {
-                    CommandLoadCodeFileToEditor c9 = new CommandLoadCodeFileToEditor(mf, f, true);
-                    c9.execute();
+                    new CommandLoadCodeFileToEditor(mf, f, true).execute();
                     mf.setLoadedCodeFilePath(f.getAbsolutePath());
                 }
             }

--- a/src/openDLX/gui/command/userLevel/CommandLoadFileBelow.java
+++ b/src/openDLX/gui/command/userLevel/CommandLoadFileBelow.java
@@ -51,8 +51,7 @@ public class CommandLoadFileBelow implements Command
             {
                 if (f != null)
                 {
-                    CommandLoadCodeFileToEditor c9 = new CommandLoadCodeFileToEditor(mf, f, false);
-                    c9.execute();
+                    new CommandLoadCodeFileToEditor(mf, f, false).execute();
                 }
             }
             catch (Exception e)

--- a/src/openDLX/gui/command/userLevel/CommandLoadFrameConfigurationUsrLevel.java
+++ b/src/openDLX/gui/command/userLevel/CommandLoadFrameConfigurationUsrLevel.java
@@ -22,6 +22,7 @@
 package openDLX.gui.command.userLevel;
 
 import javax.swing.JOptionPane;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.command.systemLevel.CommandLoadFrameConfigurationSysLevel;
@@ -39,21 +40,19 @@ public class CommandLoadFrameConfigurationUsrLevel implements Command
     @Override
     public void execute()
     {
-        if (!mf.isRunning())
+        if (!mf.isRunning() && (JOptionPane.showConfirmDialog(mf,
+                "Current window configuration will be lost. Proceed?")) ==
+                JOptionPane.YES_OPTION)
         {
-            if ((JOptionPane.showConfirmDialog(mf, "Current window configuration will be lost. Proceed?")) == JOptionPane.YES_OPTION)
+            try
             {
-                try
-                {
-                    CommandLoadFrameConfigurationSysLevel c10 = new CommandLoadFrameConfigurationSysLevel(mf);
-                    c10.execute();
-                }
-                catch (Exception e)
-                {
-                    System.err.println(e.toString());
-                    e.printStackTrace();
-                    JOptionPane.showMessageDialog(mf, "loading frame preferences failed");
-                }
+                new CommandLoadFrameConfigurationSysLevel(mf).execute();
+            }
+            catch (Exception e)
+            {
+                System.err.println(e.toString());
+                e.printStackTrace();
+                JOptionPane.showMessageDialog(mf, "loading frame preferences failed");
             }
         }
 

--- a/src/openDLX/gui/command/userLevel/CommandResetCurrentProgram.java
+++ b/src/openDLX/gui/command/userLevel/CommandResetCurrentProgram.java
@@ -45,14 +45,11 @@ public class CommandResetCurrentProgram implements Command
         {
             File configFile = new File(mf.getConfigFile().getAbsolutePath());
             //save current window position
-            CommandSaveFrameConfigurationSysLevel c11 = new CommandSaveFrameConfigurationSysLevel(mf);
-            c11.execute();
+            new CommandSaveFrameConfigurationSysLevel(mf).execute();
             //delete old openDLX and clean/remove all frames
-            CommandResetSimulator c10 = new CommandResetSimulator(mf);
-            c10.execute();
+            new CommandResetSimulator(mf).execute();
             //initialize openDLX and create internal frames, set status to executing
-            CommandStartExecuting c7 = new CommandStartExecuting(mf, configFile);
-            c7.execute();
+            new CommandStartExecuting(mf, configFile).execute();
         }
     }
 

--- a/src/openDLX/gui/command/userLevel/CommandRun.java
+++ b/src/openDLX/gui/command/userLevel/CommandRun.java
@@ -41,8 +41,7 @@ public class CommandRun implements Command
         //check if the main frame is executing/openDLX is loaded
         if (mf.isExecuting() && mf.isUpdateAllowed())
         {
-            Thread t10 = new Thread(new ThreadCommandRun(mf));
-            t10.start();
+            new Thread(new ThreadCommandRun(mf)).start();
         }
     }
 

--- a/src/openDLX/gui/command/userLevel/CommandRunFromConfigurationFile.java
+++ b/src/openDLX/gui/command/userLevel/CommandRunFromConfigurationFile.java
@@ -22,6 +22,7 @@
 package openDLX.gui.command.userLevel;
 
 import java.io.File;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.command.systemLevel.CommandOpenConfigFile;
@@ -45,28 +46,22 @@ public class CommandRunFromConfigurationFile implements Command
         if (!mf.isRunning())
         {
             //save current window position
-            CommandSaveFrameConfigurationSysLevel c11 = new CommandSaveFrameConfigurationSysLevel(mf);
-            c11.execute();
+            new CommandSaveFrameConfigurationSysLevel(mf).execute();
             //show filechooser dialog and choose file
             CommandOpenConfigFile c10 = new CommandOpenConfigFile(mf);
             c10.execute();
             //get chosen file
             File configFile = c10.getConfigFile();
 
-
             //file is null if user canceled filechooser dialog
             if (configFile != null)
             {
                 //reset simulator before loading new content
-                CommandResetSimulator cr = new CommandResetSimulator(mf);
-                cr.execute();
+                new CommandResetSimulator(mf).execute();
 
                 //initialize openDLX and create internal frames, set status to executing
-                CommandStartExecuting c7 = new CommandStartExecuting(mf, configFile);
-                c7.execute();
-
+                new CommandStartExecuting(mf, configFile).execute();
             }
-
         }
     }
 

--- a/src/openDLX/gui/command/userLevel/CommandRunFromEditor.java
+++ b/src/openDLX/gui/command/userLevel/CommandRunFromEditor.java
@@ -47,46 +47,36 @@ public class CommandRunFromEditor implements Command
     @Override
     public void execute()
     {
-
         MainFrame mf = MainFrame.getInstance();
         if (!mf.isRunning())
         {
             //save current window position
-            CommandSaveFrameConfigurationSysLevel c11 = new CommandSaveFrameConfigurationSysLevel(mf);
-            c11.execute();
+            new CommandSaveFrameConfigurationSysLevel(mf).execute();
             //create new temporary file
             CommandWriteToTmpFile c10 = new CommandWriteToTmpFile(ef.getText());
             c10.execute();
             File tmpFile = c10.getTmpFile();
-
-
-
 
             if (tmpFile != null)
             {
                 CommandCompileCode c8 = new CommandCompileCode(mf, tmpFile);
                 c8.execute();
                 File configFile = c8.getConfigFile();
+
                 JInternalFrame[] intFrames = mf.getinternalFrames();
                 String[] intFrameOrder = new String[intFrames.length];
                 for (int i = 0; i < intFrames.length; ++i)
                     intFrameOrder[i] = intFrames[i].getTitle();
 
-                if (configFile != null)
                 //reset simulator before loading new content
+                if (configFile != null)
                 {
-                    CommandResetSimulator cr = new CommandResetSimulator(mf);
-                    cr.execute();
-
+                    new CommandResetSimulator(mf).execute();
 
                     //initialize openDLX and create internal frames, set status to executing
-                    CommandStartExecuting c7 = new CommandStartExecuting(mf, configFile, intFrameOrder);
-                    c7.execute();
+                    new CommandStartExecuting(mf, configFile, intFrameOrder).execute();
                 }
-
-
             }
-
         }
     }
 

--- a/src/openDLX/gui/command/userLevel/CommandRunSlowly.java
+++ b/src/openDLX/gui/command/userLevel/CommandRunSlowly.java
@@ -41,9 +41,8 @@ public class CommandRunSlowly implements Command
     { //check if state is executing and check if the current openDLX has finished (when it has finished ->updates are no longer allowed)
         if (mf.isExecuting() && mf.isUpdateAllowed())
         {
-            Thread t10 = new Thread(new ThreadCommandRunSlowly(mf));
-            t10.start();
-            Player p = new Player(mf);
+            new Thread(new ThreadCommandRunSlowly(mf)).start();
+            new Player(mf);
         }
     }
 

--- a/src/openDLX/gui/command/userLevel/CommandSave.java
+++ b/src/openDLX/gui/command/userLevel/CommandSave.java
@@ -26,7 +26,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+
 import javax.swing.JOptionPane;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.dialog.FileSaver;
@@ -42,18 +44,15 @@ public class CommandSave implements Command
         {
             mf.getContentPane().setCursor(
                     Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-            FileSaver fs = new FileSaver();
-            File saveFile = fs.saveAs(mf);
+            File saveFile = new FileSaver().saveAs(mf);
             mf.getContentPane().setCursor(
                     Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
             if (saveFile != null)
             {
-                String text = mf.getEditorText();
-
                 try
                 {
                     BufferedWriter out = new BufferedWriter(new FileWriter(saveFile.getAbsolutePath()));
-                    out.write(text);
+                    out.write(mf.getEditorText());
                     out.close();
                 }
                 catch (IOException e)
@@ -61,9 +60,7 @@ public class CommandSave implements Command
                     System.out.println("Exception ");
                     e.printStackTrace();
                     JOptionPane.showMessageDialog(mf, "Saving file failed: " + e.toString());
-
                 }
-
             }
         }
     }

--- a/src/openDLX/gui/command/userLevel/CommandSaveFrameConfigurationUsrLevel.java
+++ b/src/openDLX/gui/command/userLevel/CommandSaveFrameConfigurationUsrLevel.java
@@ -22,6 +22,7 @@
 package openDLX.gui.command.userLevel;
 
 import javax.swing.JOptionPane;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.gui.command.systemLevel.CommandSaveFrameConfigurationSysLevel;
@@ -39,24 +40,21 @@ public class CommandSaveFrameConfigurationUsrLevel implements Command
     @Override
     public void execute()
     {
-        if (!mf.isRunning())
+        if (!mf.isRunning() && (JOptionPane.showConfirmDialog(mf,
+                "Saving current window configuration will overwrite old configuration. Proceed ?")) ==
+                JOptionPane.YES_OPTION)
         {
-            if ((JOptionPane.showConfirmDialog(mf, "Saving current window configuration will overwrite old configuration. Proceed ?")) == JOptionPane.YES_OPTION)
+            try
             {
-                try
-                {
-                    CommandSaveFrameConfigurationSysLevel c1 = new CommandSaveFrameConfigurationSysLevel(mf);
-                    c1.execute();
-                }
-                catch (Exception e)
-                {
-                    System.err.println(e.toString());
-                    e.printStackTrace();
-                    JOptionPane.showMessageDialog(mf, "saving frame preferences failed");
-                }
+                new CommandSaveFrameConfigurationSysLevel(mf).execute();
+            }
+            catch (Exception e)
+            {
+                System.err.println(e.toString());
+                e.printStackTrace();
+                JOptionPane.showMessageDialog(mf, "saving frame preferences failed");
             }
         }
-
     }
 
 }

--- a/src/openDLX/gui/command/userLevel/CommandShowOptionDialog.java
+++ b/src/openDLX/gui/command/userLevel/CommandShowOptionDialog.java
@@ -31,7 +31,7 @@ public class CommandShowOptionDialog implements Command
     @Override
     public void execute()
     {
-        OptionDialog op = new OptionDialog(MainFrame.getInstance());
+        new OptionDialog(MainFrame.getInstance());
     }
 
 }

--- a/src/openDLX/gui/dialog/CodeFileChooser.java
+++ b/src/openDLX/gui/dialog/CodeFileChooser.java
@@ -25,8 +25,10 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.Serializable;
+
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
+
 import openDLX.gui.Preference;
 
 @SuppressWarnings("serial")
@@ -41,8 +43,6 @@ public class CodeFileChooser implements Serializable
         final JFileChooser chooser = new JFileChooser("Choose file");
         chooser.setDialogType(JFileChooser.OPEN_DIALOG);
         chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
-
-
 
         chooser.setFileFilter(new FileFilter()
         {
@@ -61,11 +61,11 @@ public class CodeFileChooser implements Serializable
         });
 
         path = Preference.pref.get(preferenceKey, path);
-        final File file = new File(path);
 
-        chooser.setCurrentDirectory(file);
+        chooser.setCurrentDirectory(new File(path));
         chooser.addPropertyChangeListener(new PropertyChangeListener()
         {
+            @Override
             public void propertyChange(PropertyChangeEvent e)
             {
                 if (e.getPropertyName().equals(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY)
@@ -78,15 +78,16 @@ public class CodeFileChooser implements Serializable
         });
 
         chooser.setVisible(true);
-        final int result = chooser.showOpenDialog(null);
 
-        if (result == JFileChooser.APPROVE_OPTION)
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION)
         {
             path = chooser.getSelectedFile().getParent();
             Preference.pref.put(preferenceKey, path);
             return chooser.getSelectedFile();
+        } else
+        {
+            return null;
         }
-        return null;
     }
 
 }

--- a/src/openDLX/gui/dialog/ConfigFileChooser.java
+++ b/src/openDLX/gui/dialog/ConfigFileChooser.java
@@ -24,8 +24,10 @@ package openDLX.gui.dialog;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
+
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
+
 import openDLX.gui.Preference;
 
 public class ConfigFileChooser
@@ -40,8 +42,6 @@ public class ConfigFileChooser
         chooser.setDialogType(JFileChooser.OPEN_DIALOG);
         chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
 
-
-
         chooser.setFileFilter(new FileFilter()
         {
             @Override
@@ -55,15 +55,13 @@ public class ConfigFileChooser
             {
                 return "Configuration Files(*.cfg)";
             }
-
         });
 
         path = Preference.pref.get(preferenceKey, path);
-        final File file = new File(path);
-
-        chooser.setCurrentDirectory(file);
+        chooser.setCurrentDirectory(new File(path));
         chooser.addPropertyChangeListener(new PropertyChangeListener()
         {
+            @Override
             public void propertyChange(PropertyChangeEvent e)
             {
                 if (e.getPropertyName().equals(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY)
@@ -76,15 +74,17 @@ public class ConfigFileChooser
         });
 
         chooser.setVisible(true);
-        final int result = chooser.showOpenDialog(null);
 
-        if (result == JFileChooser.APPROVE_OPTION)
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION)
         {
             path = chooser.getSelectedFile().getParent();
             Preference.pref.put(preferenceKey, path);
             return chooser.getSelectedFile();
         }
-        return null;
+        else
+        {
+            return null;
+        }
     }
 
 }

--- a/src/openDLX/gui/dialog/FileSaver.java
+++ b/src/openDLX/gui/dialog/FileSaver.java
@@ -22,16 +22,18 @@
 package openDLX.gui.dialog;
 
 import java.io.File;
+
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.Preference;
 
 public class FileSaver
 {
 
-	// FIXME using static string here ...
+    // FIXME using static string here ...
     private String path = "/home";
     private String preferenceKey = "savefilechooserpath";
 
@@ -45,7 +47,7 @@ public class FileSaver
             public void approveSelection()
             {
                 File f = getSelectedFile();
-                if (f.exists() && getDialogType() == SAVE_DIALOG)
+                if (f.exists())
                 {
                     int result = JOptionPane.showConfirmDialog(this, "The file exists, overwrite?", "Existing file", JOptionPane.YES_NO_CANCEL_OPTION);
                     switch (result)
@@ -53,12 +55,10 @@ public class FileSaver
                         case JOptionPane.YES_OPTION:
                             super.approveSelection();
                             return;
-                        case JOptionPane.NO_OPTION:
-                            return;
-                        case JOptionPane.CLOSED_OPTION:
-                            return;
                         case JOptionPane.CANCEL_OPTION:
                             cancelSelection();
+                        case JOptionPane.NO_OPTION:
+                        case JOptionPane.CLOSED_OPTION:
                             return;
                     }
                 }
@@ -82,21 +82,20 @@ public class FileSaver
             {
                 return "Assembler Files(*.s)";
             }
-
         });
 
-
         chooser.setSelectedFile(new File(mf.getLoadedCodeFilePath()));
-        final int result = chooser.showSaveDialog(mf);
 
-        if (result == JFileChooser.APPROVE_OPTION)
+        if (chooser.showSaveDialog(mf) == JFileChooser.APPROVE_OPTION)
         {
             path = chooser.getSelectedFile().getParent();
             Preference.pref.put(preferenceKey, path);
             return chooser.getSelectedFile();
         }
-        return null;
-
+        else
+        {
+            return null;
+        }
     }
 
 }

--- a/src/openDLX/gui/internalframes/factories/InternalFrameFactory.java
+++ b/src/openDLX/gui/internalframes/factories/InternalFrameFactory.java
@@ -38,8 +38,7 @@ public class InternalFrameFactory
 {
     //here you find every frames title -> preferences depend on names
 
-    private MainFrame mf;
-    static final private Hashtable<Class<?>, String> frameNames = new Hashtable<Class<?>, String>();
+    private static final Hashtable<Class<?>, String> frameNames = new Hashtable<Class<?>, String>();
     private static InternalFrameFactory instance = null;
     
     private static final String FRAME_NAME_EDITOR = "coding frame";
@@ -49,6 +48,7 @@ public class InternalFrameFactory
     private static final String FRAME_NAME_STATS = "statistics";
     private static final String FRAME_NAME_LOG = "log";
     private static final String FRAME_NAME_CLOCKCYCLE = "cycles and pipeline";
+    private MainFrame mf;
 
     static
     {
@@ -106,8 +106,7 @@ public class InternalFrameFactory
                 createClockCycleFrame();
         }
 
-        CommandLoadFrameConfigurationSysLevel c10 = new CommandLoadFrameConfigurationSysLevel(mf);
-        c10.execute();
+        new CommandLoadFrameConfigurationSysLevel(mf).execute();
     }
 
     public static String getFrameName(Class<?> c)
@@ -117,36 +116,36 @@ public class InternalFrameFactory
 
     public void createMemoryFrame(MainFrame mf)
     {
-        MemoryFrame f = new MemoryFrame(frameNames.get(MemoryFrame.class).toString(),mf);
+        MemoryFrame f = new MemoryFrame(frameNames.get(MemoryFrame.class),mf);
         mf.addInternalFrame(f);
     }
 
     private void createRegisterFrame()
     {
-        RegisterFrame rf = new RegisterFrame(frameNames.get(RegisterFrame.class).toString());
+        RegisterFrame rf = new RegisterFrame(frameNames.get(RegisterFrame.class));
         mf.addInternalFrame(rf);
     }
 
     private void createCodeFrame()
     {
-        CodeFrame cf = new CodeFrame(frameNames.get(CodeFrame.class).toString());
+        CodeFrame cf = new CodeFrame(frameNames.get(CodeFrame.class));
         mf.addInternalFrame(cf);
     }
 
     private void createStatisticsFrame()
     {
-        StatisticsFrame sf = new StatisticsFrame(frameNames.get(StatisticsFrame.class).toString());
+        StatisticsFrame sf = new StatisticsFrame(frameNames.get(StatisticsFrame.class));
         mf.addInternalFrame(sf);
     }
 
     private void createLogFrame()
     {
-        LogFrame lf = new LogFrame(frameNames.get(LogFrame.class).toString());
+        LogFrame lf = new LogFrame(frameNames.get(LogFrame.class));
         mf.addInternalFrame(lf);
     }
      private void createClockCycleFrame()
     {
-        ClockCycleFrame ccf = new ClockCycleFrame(frameNames.get(ClockCycleFrame.class).toString());
+        ClockCycleFrame ccf = new ClockCycleFrame(frameNames.get(ClockCycleFrame.class));
         mf.addInternalFrame(ccf);
     }
 }


### PR DESCRIPTION
These commits are purely costmetic changes to improve (IMHO) code readability.

The command-pattern architecture used in the GUI part of the simulator causes a number of one-shot objects to be created; these need not be assigned to a variable, but can be used in a single statement (calling `execute()` on the object returned by the constructor).

Other changes include stripping of trailing whitespace and superfluous empty lines and using extended `for`-loops when the loop index is not used or needed.

I have tested this quickly on Ubuntu 13.04 64bit with a current JDK/JRE. I recommend testing it on other platforms as well, just to make sure none of the changes actually break anything (they're _supposed_ to be cosmetic, but I might have messed something up, you never know).
