### PR TITLE
Common superclass for Filechoosers and fix line duplication bug in LogReader

### DIFF
--- a/src/openDLX/gui/dialog/CodeFileChooser.java
+++ b/src/openDLX/gui/dialog/CodeFileChooser.java
@@ -21,30 +21,22 @@
  ******************************************************************************/
 package openDLX.gui.dialog;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.io.Serializable;
 
-import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
-import openDLX.gui.Preference;
-
-@SuppressWarnings("serial")
-public class CodeFileChooser implements Serializable
+public class CodeFileChooser extends CommonFileChooser
 {
-
-    private String path = "/home";
-    private String preferenceKey = "codefilechooserpath";
-
-    public File chooseFile()
+    public CodeFileChooser()
     {
-        final JFileChooser chooser = new JFileChooser("Choose file");
-        chooser.setDialogType(JFileChooser.OPEN_DIALOG);
-        chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+        super();
+        preferenceKey = "codefilechooserpath";
+    }
 
-        chooser.setFileFilter(new FileFilter()
+    @Override
+    protected FileFilter getFileFilter()
+    {
+        return new FileFilter()
         {
             @Override
             public boolean accept(File f)
@@ -55,39 +47,8 @@ public class CodeFileChooser implements Serializable
             @Override
             public String getDescription()
             {
-                return "Assembler Files(*.s)";
+                return "Assembler Files (*.s)";
             }
-
-        });
-
-        path = Preference.pref.get(preferenceKey, path);
-
-        chooser.setCurrentDirectory(new File(path));
-        chooser.addPropertyChangeListener(new PropertyChangeListener()
-        {
-            @Override
-            public void propertyChange(PropertyChangeEvent e)
-            {
-                if (e.getPropertyName().equals(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY)
-                        || e.getPropertyName().equals(JFileChooser.DIRECTORY_CHANGED_PROPERTY))
-                {
-                    e.getNewValue();
-                }
-            }
-
-        });
-
-        chooser.setVisible(true);
-
-        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION)
-        {
-            path = chooser.getSelectedFile().getParent();
-            Preference.pref.put(preferenceKey, path);
-            return chooser.getSelectedFile();
-        } else
-        {
-            return null;
-        }
+        };
     }
-
 }

--- a/src/openDLX/gui/dialog/CommonFileChooser.java
+++ b/src/openDLX/gui/dialog/CommonFileChooser.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * openDLX - A DLX/MIPS processor simulator.
+ * Copyright (C) 2013 The openDLX project, University of Augsburg, Germany
+ * Project URL: <https://sourceforge.net/projects/opendlx>
+ * Development branch: <https://github.com/smetzlaff/openDLX>
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program, see <LICENSE>. If not, see
+ * <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package openDLX.gui.dialog;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileFilter;
+
+import openDLX.gui.Preference;
+
+public abstract class CommonFileChooser {
+
+    protected String preferenceKey;
+    private String path = "/home";
+
+    public CommonFileChooser() {
+        super();
+    }
+
+    protected abstract FileFilter getFileFilter();
+
+    public File chooseFile() {
+        final JFileChooser chooser = new JFileChooser("Choose file");
+        chooser.setDialogType(JFileChooser.OPEN_DIALOG);
+        chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+
+        chooser.setFileFilter(getFileFilter());
+
+        path = Preference.pref.get(preferenceKey, path);
+        chooser.setCurrentDirectory(new File(path));
+        chooser.addPropertyChangeListener(new PropertyChangeListener()
+        {
+            @Override
+            public void propertyChange(PropertyChangeEvent e)
+            {
+                if (e.getPropertyName().equals(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY)
+                        || e.getPropertyName().equals(JFileChooser.DIRECTORY_CHANGED_PROPERTY))
+                {
+                    e.getNewValue();
+                }
+            }
+
+        });
+
+        chooser.setVisible(true);
+
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION)
+        {
+            path = chooser.getSelectedFile().getParent();
+            Preference.pref.put(preferenceKey, path);
+            return chooser.getSelectedFile();
+        }
+        else
+        {
+            return null;
+        }
+    }
+}

--- a/src/openDLX/gui/dialog/ConfigFileChooser.java
+++ b/src/openDLX/gui/dialog/ConfigFileChooser.java
@@ -21,28 +21,22 @@
  ******************************************************************************/
 package openDLX.gui.dialog;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
 
-import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
-import openDLX.gui.Preference;
-
-public class ConfigFileChooser
+public class ConfigFileChooser extends CommonFileChooser
 {
-
-    private String path = "/home";
-    private String preferenceKey = "configfilechooserpath";
-
-    public File chooseFile()
+    public ConfigFileChooser()
     {
-        final JFileChooser chooser = new JFileChooser("Choose file");
-        chooser.setDialogType(JFileChooser.OPEN_DIALOG);
-        chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+        super();
+        preferenceKey = "configfilechooserpath";
+    }
 
-        chooser.setFileFilter(new FileFilter()
+    @Override
+    protected FileFilter getFileFilter()
+    {
+        return new FileFilter()
         {
             @Override
             public boolean accept(File f)
@@ -53,38 +47,8 @@ public class ConfigFileChooser
             @Override
             public String getDescription()
             {
-                return "Configuration Files(*.cfg)";
+                return "Configuration Files (*.cfg)";
             }
-        });
-
-        path = Preference.pref.get(preferenceKey, path);
-        chooser.setCurrentDirectory(new File(path));
-        chooser.addPropertyChangeListener(new PropertyChangeListener()
-        {
-            @Override
-            public void propertyChange(PropertyChangeEvent e)
-            {
-                if (e.getPropertyName().equals(JFileChooser.SELECTED_FILE_CHANGED_PROPERTY)
-                        || e.getPropertyName().equals(JFileChooser.DIRECTORY_CHANGED_PROPERTY))
-                {
-                    e.getNewValue();
-                }
-            }
-
-        });
-
-        chooser.setVisible(true);
-
-        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION)
-        {
-            path = chooser.getSelectedFile().getParent();
-            Preference.pref.put(preferenceKey, path);
-            return chooser.getSelectedFile();
-        }
-        else
-        {
-            return null;
-        }
+        };
     }
-
 }


### PR DESCRIPTION
These are two small fixes:
- Pull the common functionality of `CodeFileChooser` and `ConfigFileChooser` (which is a lot) into a common superclass to reduce code duplication
- Fix a bug in `LogReader` where lines would be added to the log frame (viewer) multiple times if more than one item was in the `forbidden` categories list. (This is currently not the case; I stumbled over this bug while doing style clean-up and thought this would save some headache for whoever next touches that list). This commit also contains style fixes (indentation, whitespace, extended `for` loops, etc)
