### PR TITLE
Improve code readability (4) and clean up code

### DIFF
--- a/src/openDLX/datatypes/ArchCfg.java
+++ b/src/openDLX/datatypes/ArchCfg.java
@@ -22,8 +22,9 @@
 package openDLX.datatypes;
 
 import java.util.Properties;
-import openDLX.gui.Preference;
+
 import openDLX.BranchPredictionModule;
+import openDLX.gui.Preference;
 
 public class ArchCfg
 {
@@ -32,10 +33,10 @@ public class ArchCfg
 
     // forwarding implies the two boolean: use_forwarding and use_load_stall_bubble
     public static boolean use_forwarding = Preference.pref.getBoolean(Preference.forwardingPreferenceKey, true);
-    
+
     // TODO: rename variable
     public static boolean  use_load_stall_bubble = Preference.pref.getBoolean(Preference.mipsCompatibilityPreferenceKey, true);
-    
+
     public static final String[] GP_NAMES_MIPS =
     {
         "ze", "at", "v0", "v1", "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "t4", "t5", "t6", "t7",
@@ -46,21 +47,38 @@ public class ArchCfg
         "r0 ", "r1 ", "r2 ", "r3 ", "r4 ", "r5 ", "r6 ", "r7 ", "r8 ", "r9 ", "r10", "r11", "r12", "r13", "r14", "r15",
         "r16", "r17", "r18", "r19", "r20", "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29", "r30", "r31"
     };
-        
-    public static BranchPredictorType branch_predictor_type = BranchPredictionModule.getBranchPredictorTypeFromString(Preference.pref.get(Preference.bpTypePreferenceKey, ""));
-    public static final Object[] possibleBpTypeComboBoxValues =
+
+    public static BranchPredictorType branch_predictor_type =
+            BranchPredictionModule.getBranchPredictorTypeFromString(
+                    Preference.pref.get(Preference.bpTypePreferenceKey, ""));
+    public static final String[] possibleBpTypeComboBoxValues =
     {
-        BranchPredictorType.UNKNOWN.toGuiString(), BranchPredictorType.S_ALWAYS_NOT_TAKEN.toGuiString(), BranchPredictorType.S_ALWAYS_TAKEN.toGuiString(), BranchPredictorType.S_BACKWARD_TAKEN.toGuiString(), BranchPredictorType.D_1BIT.toGuiString(), BranchPredictorType.D_2BIT_SATURATION.toGuiString(), BranchPredictorType.D_2BIT_HYSTERESIS.toGuiString()
+        BranchPredictorType.UNKNOWN.toGuiString(),
+        BranchPredictorType.S_ALWAYS_NOT_TAKEN.toGuiString(),
+        BranchPredictorType.S_ALWAYS_TAKEN.toGuiString(),
+        BranchPredictorType.S_BACKWARD_TAKEN.toGuiString(),
+        BranchPredictorType.D_1BIT.toGuiString(),
+        BranchPredictorType.D_2BIT_SATURATION.toGuiString(),
+        BranchPredictorType.D_2BIT_HYSTERESIS.toGuiString()
     };
-    
-    public static BranchPredictorState branch_predictor_initial_state = BranchPredictionModule.getBranchPredictorInitialStateFromString(Preference.pref.get(Preference.bpInitialStatePreferenceKey, ""));
-    public static final Object[] possibleBpInitialStateComboBoxValues =
+
+    public static BranchPredictorState branch_predictor_initial_state =
+            BranchPredictionModule.getBranchPredictorInitialStateFromString(
+                    Preference.pref.get(Preference.bpInitialStatePreferenceKey, ""));
+    public static final String[] possibleBpInitialStateComboBoxValues =
     {
-        BranchPredictorState.UNKNOWN.toGuiString(), BranchPredictorState.PREDICT_NOT_TAKEN.toGuiString(), BranchPredictorState.PREDICT_TAKEN.toGuiString(), BranchPredictorState.PREDICT_WEAKLY_NOT_TAKEN.toGuiString(), BranchPredictorState.PREDICT_WEAKLY_TAKEN.toGuiString(), BranchPredictorState.PREDICT_STRONGLY_NOT_TAKEN.toGuiString(), BranchPredictorState.PREDICT_WEAKLY_TAKEN.toGuiString()
+        BranchPredictorState.UNKNOWN.toGuiString(),
+        BranchPredictorState.PREDICT_NOT_TAKEN.toGuiString(),
+        BranchPredictorState.PREDICT_TAKEN.toGuiString(),
+        BranchPredictorState.PREDICT_WEAKLY_NOT_TAKEN.toGuiString(),
+        BranchPredictorState.PREDICT_WEAKLY_TAKEN.toGuiString(),
+        BranchPredictorState.PREDICT_STRONGLY_NOT_TAKEN.toGuiString(),
+        BranchPredictorState.PREDICT_WEAKLY_TAKEN.toGuiString()
     };
-    public static int branch_predictor_table_size = Preference.pref.getInt(Preference.btbSizePreferenceKey, 1);
-    
-    
+    public static int branch_predictor_table_size = Preference.pref.getInt(
+            Preference.btbSizePreferenceKey, 1);
+
+
     public static int max_cycles = Preference.pref.getInt(Preference.maxCyclesPreferenceKey, 1000);
 
     public static void registerArchitectureConfig(Properties config)
@@ -83,7 +101,7 @@ public class ArchCfg
 
         return ISAType.UNKNOWN_ISA;
     }
-    
+
     private static boolean getUseForwardingCfg(Properties config)
     {
         if (ArchCfg.isa_type == ISAType.MIPS)

--- a/src/openDLX/gui/command/systemLevel/CommandLoadCodeFileToEditor.java
+++ b/src/openDLX/gui/command/systemLevel/CommandLoadCodeFileToEditor.java
@@ -23,7 +23,9 @@ package openDLX.gui.command.systemLevel;
 
 import java.awt.Cursor;
 import java.io.File;
+
 import javax.swing.JOptionPane;
+
 import openDLX.gui.MainFrame;
 import openDLX.gui.command.Command;
 import openDLX.util.CodeLoader;
@@ -45,7 +47,6 @@ public class CommandLoadCodeFileToEditor implements Command
     @Override
     public void execute()
     {
-
         try
         {
             mf.getContentPane().setCursor(
@@ -54,21 +55,15 @@ public class CommandLoadCodeFileToEditor implements Command
             String help = codeFile.getAbsolutePath().replace("\\", "/");
             String text;
             if (clean == true)
-            {
                 text = "";
-            }
             else
-            {
-                text = mf.getEditorText();
-                text += "\n";
-            }
+                text = mf.getEditorText() + "\n";
             text += CodeLoader.loadCode(help);
             mf.setEditorText(text);
             mf.setEditorSavedState();
         }
         catch (Exception e)
         {
-
             System.err.println(e.toString());
             e.printStackTrace();
             JOptionPane.showMessageDialog(mf, "Loading File into editor failed");
@@ -79,5 +74,4 @@ public class CommandLoadCodeFileToEditor implements Command
                     Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
         }
     }
-
 }

--- a/src/openDLX/gui/command/systemLevel/ThreadCommandRunSlowly.java
+++ b/src/openDLX/gui/command/systemLevel/ThreadCommandRunSlowly.java
@@ -23,10 +23,10 @@ package openDLX.gui.command.systemLevel;
 
 import java.awt.EventQueue;
 
+import openDLX.OpenDLXSimulator;
 import openDLX.exception.PipelineException;
 import openDLX.gui.GUI_CONST;
 import openDLX.gui.MainFrame;
-import openDLX.OpenDLXSimulator;
 
 public class ThreadCommandRunSlowly implements Runnable
 {
@@ -75,8 +75,7 @@ public class ThreadCommandRunSlowly implements Runnable
                     public void run()
                     {
                         //update frames
-                        CommandUpdateFrames c10 = new CommandUpdateFrames(mf);
-                        c10.execute();
+                        new CommandUpdateFrames(mf).execute();
                     }
 
                 });
@@ -92,15 +91,12 @@ public class ThreadCommandRunSlowly implements Runnable
         }
         // when running stops or openDLX has finished, set state back to executing, as executing means a openDLX is loaded but not running through
         mf.setOpenDLXSimState(GUI_CONST.OpenDLXSimState.EXECUTING);
-        // if the current openDLX has finished, dont allow any gui updates any more 
+        // if the current openDLX has finished, dont allow any gui updates any more
         if (openDLXSim.isFinished())
         {
             mf.setUpdateAllowed(false);
-            CommandSimulatorFinishedInfo c3 = new CommandSimulatorFinishedInfo();
-            c3.execute();
+            new CommandSimulatorFinishedInfo().execute();
         }
-
-
     }
 
 }

--- a/src/openDLX/gui/command/userLevel/CommandChangeWindowVisibility.java
+++ b/src/openDLX/gui/command/userLevel/CommandChangeWindowVisibility.java
@@ -32,12 +32,12 @@ import openDLX.gui.menubar.OpenDLXSimMenuItem;
 public class CommandChangeWindowVisibility implements Command
 {
 
-    private OpenDLXSimMenuItem internal_frame_item;
+    private OpenDLXSimMenuItem internalFrameMenuItem;
     private MainFrame mf;
 
-    public CommandChangeWindowVisibility(OpenDLXSimMenuItem frame_item, MainFrame mf)
+    public CommandChangeWindowVisibility(OpenDLXSimMenuItem internalFrameMenuItem, MainFrame mf)
     {
-        this.internal_frame_item = frame_item;
+        this.internalFrameMenuItem = internalFrameMenuItem;
         this.mf = mf;
     }
 
@@ -46,32 +46,35 @@ public class CommandChangeWindowVisibility implements Command
     {
         for (JInternalFrame internalFrame : mf.getinternalFrames())
         {
-            if (internalFrame.getTitle().equals(internal_frame_item.getName()))
+            if (internalFrame.getTitle().equals(internalFrameMenuItem.getName()))
             {
-            	if(internalFrame.isIcon())
-				 {
-					try {
-						internalFrame.setIcon(false);
-					} catch (PropertyVetoException e) {
-						e.printStackTrace();
-					}
-				}
-            	if(internalFrame.isClosed() || !internalFrame.isVisible() || !internalFrame.isEnabled())
-            	{
-            		internalFrame.setVisible(true);
-            	}
-            	internalFrame.moveToFront();
+                if (internalFrame.isIcon())
+                {
+                    try {
+                        internalFrame.setIcon(false);
+                    } catch (PropertyVetoException e) {
+                        e.printStackTrace();
+                    }
+                }
+                if (internalFrame.isClosed() || !internalFrame.isVisible() ||
+                        !internalFrame.isEnabled())
+                {
+                    internalFrame.setVisible(true);
+                }
+                internalFrame.moveToFront();
+
                 try
                 {
                     internalFrame.setSelected(true);
-                } catch (PropertyVetoException e)
+                }
+                catch (PropertyVetoException e)
                 {
                     e.printStackTrace();
                 }
-            	
+
                 /* // if users closes or opens frame - should it be a preference automatically ?
                  new FrameConfiguration(internalFrame).saveFrameConfiguration();*/
-        		break;
+                break;
             }
         }
     }

--- a/src/openDLX/gui/command/userLevel/CommandShowAbout.java
+++ b/src/openDLX/gui/command/userLevel/CommandShowAbout.java
@@ -30,13 +30,16 @@ import openDLX.gui.command.Command;
 
 public class CommandShowAbout implements Command
 {
-
     @Override
     public void execute()
     {
-    	final ImageIcon icon = new ImageIcon(getClass().getResource("/img/openDLX_small.png"), "openDLX logo");    	    	
-    	JOptionPane.showMessageDialog(MainFrame.getInstance(), GlobalConfig.ABOUT, "About", JOptionPane.INFORMATION_MESSAGE, icon);
+        final ImageIcon icon = new ImageIcon(
+                getClass().getResource("/img/openDLX_small.png"),
+                "openDLX logo");
+        JOptionPane.showMessageDialog(MainFrame.getInstance(),
+                GlobalConfig.ABOUT,
+                "About",
+                JOptionPane.INFORMATION_MESSAGE,
+                icon);
     }
-
 }
-

--- a/src/openDLX/gui/dialog/OptionDialog.java
+++ b/src/openDLX/gui/dialog/OptionDialog.java
@@ -47,7 +47,6 @@ import openDLX.gui.Preference;
 public class OptionDialog extends JDialog implements ActionListener
 {
     // two control buttons, press confirm to save selected options
-
     private JButton confirm;
     private JButton cancel;
 
@@ -55,16 +54,13 @@ public class OptionDialog extends JDialog implements ActionListener
     private JCheckBox forwardingCheckBox;
     private JCheckBox mipsCompatibilityCheckBox;
 
-    /*Combo Box
-     *
-     *  JComboBox may be represented by Vectors or Arrays of Objects ( Object [])
-     * we have chosen "Object[]" to be the representation (in fact - String) for
+    /*
+     * JComboBox may be represented by Vectors or Arrays of Objects (Object [])
+     * we have chosen "String[]" to be the representation (in fact - String) for
      * the data within AsmFileLoader-class , but Vector is appropriate as well.
-     * (sorry,  JComboBox is not made for Enumeration, i made a final Object[] array,
-     * but Preference doesn't accept Object, just String)
      */
-    private JComboBox bpTypeComboBox;
-    private JComboBox bpInitialStateComboBox;
+    private JComboBox<String> bpTypeComboBox;
+    private JComboBox<String> bpInitialStateComboBox;
     private JTextField btbSizeTextField;
 
     //input text fields
@@ -101,9 +97,9 @@ public class OptionDialog extends JDialog implements ActionListener
         mipsCompatibilityCheckBox.setSelected(Preference.pref.getBoolean(Preference.mipsCompatibilityPreferenceKey, true)); // load current value
 
         // disable MIPS compatibility if no forwading is active
-        if(!forwardingCheckBox.isSelected())
+        if (!forwardingCheckBox.isSelected())
         {
-        	mipsCompatibilityCheckBox.setSelected(false);
+            mipsCompatibilityCheckBox.setSelected(false);
         }
 
         /*create a JComboBoxes
@@ -114,8 +110,9 @@ public class OptionDialog extends JDialog implements ActionListener
 
         // bpType:
         JLabel bpTypeComboBoxDescriptionLabel = new JLabel("Branch Predictor: ");
-        bpTypeComboBox = new JComboBox(ArchCfg.possibleBpTypeComboBoxValues);
-        bpTypeComboBox.setSelectedItem(BranchPredictionModule.getBranchPredictorTypeFromString(Preference.pref.get(Preference.bpTypePreferenceKey, BranchPredictorType.UNKNOWN.toString())).toGuiString()); // load current value
+        bpTypeComboBox = new JComboBox<String>(ArchCfg.possibleBpTypeComboBoxValues);
+        bpTypeComboBox.setSelectedItem(BranchPredictionModule.getBranchPredictorTypeFromString(
+                Preference.pref.get(Preference.bpTypePreferenceKey, BranchPredictorType.UNKNOWN.toString())).toGuiString()); // load current value
         //surrounding panel
         JPanel bpTypeListPanel = new JPanel();
         //add the label
@@ -125,8 +122,9 @@ public class OptionDialog extends JDialog implements ActionListener
 
         // bpInitialState:
         JLabel bpInitialStateComboBoxDescriptionLabel = new JLabel("Initial Predictor State: ");
-        bpInitialStateComboBox = new JComboBox(ArchCfg.possibleBpInitialStateComboBoxValues);
-        bpInitialStateComboBox.setSelectedItem(BranchPredictionModule.getBranchPredictorInitialStateFromString(Preference.pref.get(Preference.bpInitialStatePreferenceKey, BranchPredictorState.UNKNOWN.toString())).toGuiString()); // load current value
+        bpInitialStateComboBox = new JComboBox<String>(ArchCfg.possibleBpInitialStateComboBoxValues);
+        bpInitialStateComboBox.setSelectedItem(BranchPredictionModule.getBranchPredictorInitialStateFromString(
+                Preference.pref.get(Preference.bpInitialStatePreferenceKey, BranchPredictorState.UNKNOWN.toString())).toGuiString()); // load current value
         //surrounding panel
         JPanel bpInitialStateListPanel = new JPanel();
         //add the label
@@ -185,7 +183,6 @@ public class OptionDialog extends JDialog implements ActionListener
         pack();
         setResizable(false);
         setVisible(true);
-
     }
 
     @Override
@@ -203,39 +200,40 @@ public class OptionDialog extends JDialog implements ActionListener
          */
         if (e.getSource().equals(confirm))
         {
-            Preference.pref.putBoolean(Preference.forwardingPreferenceKey, forwardingCheckBox.isSelected());
-            Preference.pref.putBoolean(Preference.mipsCompatibilityPreferenceKey, mipsCompatibilityCheckBox.isSelected());
+            Preference.pref.putBoolean(Preference.forwardingPreferenceKey,
+                    forwardingCheckBox.isSelected());
+            Preference.pref.putBoolean(Preference.mipsCompatibilityPreferenceKey,
+                    mipsCompatibilityCheckBox.isSelected());
             if (forwardingCheckBox.isSelected())
             {
-            	ArchCfg.use_forwarding = true;
-            	if(mipsCompatibilityCheckBox.isSelected())
-            	{
-            		ArchCfg.use_load_stall_bubble = true;
-            	}
-            	else
-            	{
-            		ArchCfg.use_load_stall_bubble = false;
-            	}
+                ArchCfg.use_forwarding = true;
+                if(mipsCompatibilityCheckBox.isSelected())
+                {
+                    ArchCfg.use_load_stall_bubble = true;
+                }
+                else
+                {
+                    ArchCfg.use_load_stall_bubble = false;
+                }
 
             }
             else
             {
-            	ArchCfg.use_forwarding = false;
-            	ArchCfg.use_load_stall_bubble = false;
+                ArchCfg.use_forwarding = false;
+                ArchCfg.use_load_stall_bubble = false;
 
-            	if(mipsCompatibilityCheckBox.isSelected())
-            	{
-            		// reset the MIPS compatibility
-            		mipsCompatibilityCheckBox.setSelected(false);
-            		Preference.pref.putBoolean(Preference.mipsCompatibilityPreferenceKey, false);
+                if(mipsCompatibilityCheckBox.isSelected())
+                {
+                    // reset the MIPS compatibility
+                    mipsCompatibilityCheckBox.setSelected(false);
+                    Preference.pref.putBoolean(Preference.mipsCompatibilityPreferenceKey, false);
 
-            		JOptionPane.showMessageDialog(MainFrame.getInstance(), "Reset \"MIPS compatibility mode\", since it requires activated forwarding.", "Info", JOptionPane.INFORMATION_MESSAGE);
-            	}
+                    JOptionPane.showMessageDialog(MainFrame.getInstance(), "Reset \"MIPS compatibility mode\", since it requires activated forwarding.", "Info", JOptionPane.INFORMATION_MESSAGE);
+                }
             }
 
             // propagate forwarding to menu
             propagateFWToMenu(forwardingCheckBox.isSelected());
-
 
             // TODO also add a field for disabling the branch prediction
             // TODO do some checks for the setting of the BP initial state and sizes
@@ -243,8 +241,11 @@ public class OptionDialog extends JDialog implements ActionListener
             ArchCfg.branch_predictor_type = BranchPredictionModule.getBranchPredictorTypeFromGuiString(bpTypeComboBox.getSelectedItem().toString());
             Preference.pref.put(Preference.bpTypePreferenceKey, ArchCfg.branch_predictor_type.toString());
 
-            ArchCfg.branch_predictor_initial_state = BranchPredictionModule.getBranchPredictorInitialStateFromGuiString(bpInitialStateComboBox.getSelectedItem().toString());
-            Preference.pref.put(Preference.bpInitialStatePreferenceKey, ArchCfg.branch_predictor_initial_state.toString());
+            ArchCfg.branch_predictor_initial_state = BranchPredictionModule.
+                    getBranchPredictorInitialStateFromGuiString(
+                            bpInitialStateComboBox.getSelectedItem().toString());
+            Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                    ArchCfg.branch_predictor_initial_state.toString());
 
             ArchCfg.branch_predictor_table_size = Integer.parseInt(btbSizeTextField.getText());
             Preference.pref.put(Preference.btbSizePreferenceKey, btbSizeTextField.getText());
@@ -256,73 +257,79 @@ public class OptionDialog extends JDialog implements ActionListener
             case S_ALWAYS_TAKEN:
             case S_ALWAYS_NOT_TAKEN:
             case S_BACKWARD_TAKEN:
-            	// unknown and static predictors have no initial state and no branch predictor table size
-            	ArchCfg.branch_predictor_initial_state = BranchPredictorState.UNKNOWN;
-            	Preference.pref.put(Preference.bpInitialStatePreferenceKey, BranchPredictorState.UNKNOWN.toString());
+                // unknown and static predictors have no initial state and no branch predictor table size
+                ArchCfg.branch_predictor_initial_state = BranchPredictorState.UNKNOWN;
+                Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                        BranchPredictorState.UNKNOWN.toString());
 
-            	ArchCfg.branch_predictor_table_size = 1;
-            	Preference.pref.put(Preference.btbSizePreferenceKey, (new Integer(ArchCfg.branch_predictor_table_size)).toString());
-            	break;
+                ArchCfg.branch_predictor_table_size = 1;
+                Preference.pref.put(Preference.btbSizePreferenceKey,
+                        new Integer(ArchCfg.branch_predictor_table_size).toString());
+                break;
             case D_1BIT:
-            	switch(ArchCfg.branch_predictor_initial_state)
-            	{
-            	case PREDICT_STRONGLY_NOT_TAKEN:
-            	case PREDICT_WEAKLY_NOT_TAKEN:
-            		// correct 2bit states to 1 bit state
-            		ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_NOT_TAKEN;
-            		Preference.pref.put(Preference.bpInitialStatePreferenceKey, ArchCfg.branch_predictor_initial_state.toString());
-            		break;
-            	case PREDICT_STRONGLY_TAKEN:
-            	case PREDICT_WEAKLY_TAKEN:
-            		// correct 2bit states to 1 bit state
-            		ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_TAKEN;
-            		Preference.pref.put(Preference.bpInitialStatePreferenceKey, ArchCfg.branch_predictor_initial_state.toString());
-            		break;
-            	case UNKNOWN:
-            	default:
-            		ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_NOT_TAKEN;
-            		Preference.pref.put(Preference.bpInitialStatePreferenceKey, ArchCfg.branch_predictor_initial_state.toString());
-            		// TODO Throw exception
-            		break;
-            	}
-            	break;
+                switch(ArchCfg.branch_predictor_initial_state)
+                {
+                case PREDICT_STRONGLY_NOT_TAKEN:
+                case PREDICT_WEAKLY_NOT_TAKEN:
+                    // correct 2bit states to 1 bit state
+                    ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_NOT_TAKEN;
+                    Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                            ArchCfg.branch_predictor_initial_state.toString());
+                    break;
+                case PREDICT_STRONGLY_TAKEN:
+                case PREDICT_WEAKLY_TAKEN:
+                    // correct 2bit states to 1 bit state
+                    ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_TAKEN;
+                    Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                            ArchCfg.branch_predictor_initial_state.toString());
+                    break;
+                case UNKNOWN:
+                default:
+                    ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_NOT_TAKEN;
+                    Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                            ArchCfg.branch_predictor_initial_state.toString());
+                    // TODO Throw exception
+                    break;
+                }
+                break;
 
             case D_2BIT_SATURATION:
             case D_2BIT_HYSTERESIS:
-            	switch(ArchCfg.branch_predictor_initial_state)
-            	{
-            	case PREDICT_NOT_TAKEN:
-            		// correct 1bit states to 2 bit state
-            		ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_WEAKLY_NOT_TAKEN;
-            		Preference.pref.put(Preference.bpInitialStatePreferenceKey, ArchCfg.branch_predictor_initial_state.toString());
-            		break;
-            	case PREDICT_TAKEN:
-            		// correct 1bit states to 2 bit state
-            		ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_WEAKLY_TAKEN;
-            		Preference.pref.put(Preference.bpInitialStatePreferenceKey, ArchCfg.branch_predictor_initial_state.toString());
-            		break;
-            	case UNKNOWN:
-            	default:
-            		ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_WEAKLY_NOT_TAKEN;
-            		Preference.pref.put(Preference.bpInitialStatePreferenceKey, ArchCfg.branch_predictor_initial_state.toString());
-            		// TODO Throw exception
-            		break;
-            	}
-            	break;
+                switch(ArchCfg.branch_predictor_initial_state)
+                {
+                case PREDICT_NOT_TAKEN:
+                    // correct 1bit states to 2 bit state
+                    ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_WEAKLY_NOT_TAKEN;
+                    Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                            ArchCfg.branch_predictor_initial_state.toString());
+                    break;
+                case PREDICT_TAKEN:
+                    // correct 1bit states to 2 bit state
+                    ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_WEAKLY_TAKEN;
+                    Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                            ArchCfg.branch_predictor_initial_state.toString());
+                    break;
+                case UNKNOWN:
+                default:
+                    ArchCfg.branch_predictor_initial_state = BranchPredictorState.PREDICT_WEAKLY_NOT_TAKEN;
+                    Preference.pref.put(Preference.bpInitialStatePreferenceKey,
+                            ArchCfg.branch_predictor_initial_state.toString());
+                    // TODO Throw exception
+                    break;
+                }
+                break;
             }
 
             // the btb has to be a power of two
-            if(ArchCfg.branch_predictor_table_size == 0)
+            if (ArchCfg.branch_predictor_table_size == 0)
             {
-            	ArchCfg.branch_predictor_table_size = 1;
-            	Preference.pref.put(Preference.btbSizePreferenceKey, (new Integer(ArchCfg.branch_predictor_table_size)).toString());
-            	// TODO Throw exception
+                ArchCfg.branch_predictor_table_size = 1;
+                Preference.pref.put(Preference.btbSizePreferenceKey, (new Integer(ArchCfg.branch_predictor_table_size)).toString());
+                // TODO Throw exception
             }
 
             ArchCfg.max_cycles = Integer.parseInt(maxCyclesTextField.getText());
             Preference.pref.put(Preference.maxCyclesPreferenceKey, maxCyclesTextField.getText());
-
-
 
             setVisible(false);
             dispose();
@@ -333,6 +340,5 @@ public class OptionDialog extends JDialog implements ActionListener
     {
         MainFrame.getInstance().getForwardingMenuItem().setSelected(forwarding_enabled);
     }
-
 
 }

--- a/src/openDLX/gui/dialog/Output.java
+++ b/src/openDLX/gui/dialog/Output.java
@@ -26,8 +26,10 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
@@ -35,32 +37,43 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
+
 import openDLX.util.TrapObserver;
 
 @SuppressWarnings("serial")
-public class Output extends JDialog implements ActionListener, TrapObserver, KeyListener
+public class Output extends JDialog implements TrapObserver
 {
+    private static Output instance;
 
     private JTextArea textArea;
     private JButton confirm;
     private JPanel emptyPanel;
-    private static Output instance;
 
     private Output(JFrame owner)
     {
         super(owner, true);
         setLayout(new BorderLayout());
         setTitle("Output");
+
         textArea = new JTextArea();
         textArea.setEditable(false);
         textArea.setFocusable(false);
+
         JScrollPane textScroller = new JScrollPane(textArea);
         textScroller.setFocusable(false);
         textScroller.setBackground(Color.WHITE);
+
         confirm = new JButton("Close");
-        confirm.addActionListener(this);
-        confirm.addKeyListener(this);
+        confirm.addActionListener(new ActionListener()
+        {
+            @Override
+            public void actionPerformed(ActionEvent e)
+            {
+                setVisible(false);
+            }
+        });
         confirm.setFocusable(true);
+
         JPanel buttonPanel = new JPanel();
         buttonPanel.setBackground(Color.WHITE);
         buttonPanel.add(confirm);
@@ -70,7 +83,19 @@ public class Output extends JDialog implements ActionListener, TrapObserver, Key
         add(buttonPanel, BorderLayout.SOUTH);
         setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         setLocationRelativeTo(owner);
-        addKeyListener(this);
+
+        final KeyListener keylis = new KeyAdapter()
+        {
+            @Override
+            public void keyPressed(KeyEvent e)
+            {
+                if (e.getKeyCode() == KeyEvent.VK_ENTER)
+                    confirm.doClick();
+            }
+        };
+        confirm.addKeyListener(keylis);
+        addKeyListener(keylis);
+
         pack();
         setMinimumSize(new Dimension(250, 250));
     }
@@ -78,29 +103,19 @@ public class Output extends JDialog implements ActionListener, TrapObserver, Key
     public static Output getInstance(JFrame f)
     {
         if (instance == null)
-        {
             instance = new Output(f);
-        }
         return instance;
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e)
-    {
-        setVisible(false);
     }
 
     @Override
     public void update(String arg)
     {
         if (arg != null)
-        {
             addText(arg);
-        }
-        //pack(); // enables constantly growing output frame 
+
+        //pack(); // enables constantly growing output frame
         setVisible(true);
         textArea.setCaretPosition(textArea.getText().length());
-
     }
 
     @Override
@@ -113,34 +128,14 @@ public class Output extends JDialog implements ActionListener, TrapObserver, Key
     {
         textArea.setText(textArea.getText() + textToInsert);
     }
-    
+
     public void clear()
-    {	
-    	textArea.setText("");
+    {
+        textArea.setText("");
     }
 
     public String getText()
     {
         return textArea.getText();
     }
-
-    @Override
-    public void keyTyped(KeyEvent e)
-    {
-    }
-
-    @Override
-    public void keyPressed(KeyEvent e)
-    {
-        if (e.getKeyCode() == KeyEvent.VK_ENTER)
-        {
-            confirm.doClick();
-        }
-    }
-
-    @Override
-    public void keyReleased(KeyEvent e)
-    {
-    }
-
 }

--- a/src/openDLX/gui/dialog/Player.java
+++ b/src/openDLX/gui/dialog/Player.java
@@ -24,16 +24,17 @@ package openDLX.gui.dialog;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
+
 import openDLX.gui.GUI_CONST.OpenDLXSimState;
 import openDLX.gui.MainFrame;
 
 @SuppressWarnings("serial")
 public class Player extends JDialog implements ActionListener
 {
-
     private JButton play, pause, stop, times1, times2, times4, times8, times16;
 
     public Player(JFrame f)
@@ -41,6 +42,7 @@ public class Player extends JDialog implements ActionListener
         super(f, false);
         setLayout(new FlowLayout());
         setTitle("OpenDLXSimulator run");
+
         play = new JButton("Run");
         play.addActionListener(this);
         add(play);
@@ -66,60 +68,59 @@ public class Player extends JDialog implements ActionListener
         times16 = new JButton("16x");
         times16.addActionListener(this);
         add(times16);
+
         setResizable(false);
         setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
         setLocationRelativeTo(f);
+
         pack();
         setVisible(true);
-
-       
     }
 
     @Override
     public void actionPerformed(ActionEvent e)
     {
         MainFrame mf = MainFrame.getInstance();
-        if (e.getSource().equals(play))
+        if (e.getSource() == play)
         {
             pause.setEnabled(true);
             play.setEnabled(false);
             mf.setPause(false);
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT);
         }
-        if (e.getSource().equals(pause))
+        else if (e.getSource() == pause)
         {
             play.setEnabled(true);
             mf.setPause(true);
             pause.setEnabled(false);
         }
-        if (e.getSource().equals(stop))
+        else if (e.getSource() == stop)
         {
             mf.setOpenDLXSimState(OpenDLXSimState.EXECUTING);
             mf.setPause(false);
-            setVisible(false);            
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT);
+            setVisible(false);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT);
             dispose();
         }
-        if (e.getSource().equals(times1))
+        else if (e.getSource() == times1)
         {
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT);
         }
-        if (e.getSource().equals(times2))
+        else if (e.getSource() == times2)
         {
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT / 2);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT / 2);
         }
-        if (e.getSource().equals(times4))
+        else if (e.getSource() == times4)
         {
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT / 4);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT / 4);
         }
-        if (e.getSource().equals(times8))
+        else if (e.getSource() == times8)
         {
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT / 8);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT / 8);
         }
-        if (e.getSource().equals(times16))
+        else if (e.getSource() == times16)
         {
-            mf.setRunSpeed(mf.RUN_SPEED_DEFAULT / 16);
+            mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT / 16);
         }
     }
-
 }

--- a/src/openDLX/gui/internalframes/FrameConfiguration.java
+++ b/src/openDLX/gui/internalframes/FrameConfiguration.java
@@ -21,8 +21,9 @@
  ******************************************************************************/
 package openDLX.gui.internalframes;
 
+import static openDLX.gui.Preference.pref;
+
 import javax.swing.JInternalFrame;
-import static openDLX.gui.Preference.*;
 
 public class FrameConfiguration
 {
@@ -51,12 +52,14 @@ public class FrameConfiguration
 
     public void loadFrameConfiguration()
     {
-        jif.setBounds(pref.getInt(jif.getTitle() + posXPreferenceKey, jif.getX()), pref.getInt(jif.getTitle() + posYPreferenceKey, jif.getY()), pref.getInt(jif.getTitle() + sizeXPreferenceKey, jif.getWidth()), pref.getInt(jif.getTitle() + sizeYPreferenceKey, jif.getHeight()));
+        jif.setBounds(pref.getInt(jif.getTitle() + posXPreferenceKey, jif.getX()),
+                pref.getInt(jif.getTitle() + posYPreferenceKey, jif.getY()),
+                pref.getInt(jif.getTitle() + sizeXPreferenceKey, jif.getWidth()),
+                pref.getInt(jif.getTitle() + sizeYPreferenceKey, jif.getHeight()));
 
         try
         {
             jif.setVisible(pref.getBoolean(jif.getTitle() + isVisiblePreferenceKey, true));
-            
         }
         catch (Exception e)
         {
@@ -64,5 +67,4 @@ public class FrameConfiguration
             e.printStackTrace();
         }
     }
-
 }

--- a/src/openDLX/gui/internalframes/concreteframes/ClockCycleFrame.java
+++ b/src/openDLX/gui/internalframes/concreteframes/ClockCycleFrame.java
@@ -27,33 +27,34 @@ import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
+
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
+
+import openDLX.OpenDLXSimulator;
 import openDLX.asm.DLXAssembler;
 import openDLX.datatypes.uint32;
 import openDLX.exception.MemoryException;
 import openDLX.gui.GUI_CONST;
 import openDLX.gui.MainFrame;
 import openDLX.gui.internalframes.OpenDLXSimInternalFrame;
-import openDLX.gui.internalframes.util.NotSelectableTableModel;
-import openDLX.OpenDLXSimulator;
 import openDLX.gui.internalframes.renderer.ClockCycleFrameTableCellRenderer;
+import openDLX.gui.internalframes.util.NotSelectableTableModel;
 import openDLX.util.ClockCycleLog;
 
 @SuppressWarnings("serial")
 public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GUI_CONST
 {
 
-    private OpenDLXSimulator openDLXSim;
-    //frame text    
-    final private String addr_header_text = "Address";
-    final private String inst_header_text = "Instructions/Cycles";
+    private final OpenDLXSimulator openDLXSim;
+    //frame text
+    private final String addrHeaderText = "Address";
+    private final String instHeaderText = "Instructions/Cycles";
     //default size values
-    final int inst_name_max_column_width = 150;
+    private final int instructionNameMaxColWidth = 150;
     private int block = 80;
     //tables, scrollpane and table models
     private JTable table, codeTable, addrTable;
@@ -69,7 +70,7 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
     public ClockCycleFrame(String title)
     {
         super(title, true);
-        this.openDLXSim = MainFrame.getInstance().getOpenDLXSim();
+        openDLXSim = MainFrame.getInstance().getOpenDLXSim();
         initialize();
     }
 
@@ -79,7 +80,7 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
         super.initialize();
         setLayout(new BorderLayout());
 
-        //Code Table 
+        //Code Table
         codeModel = new NotSelectableTableModel();
         codeTable = new JTable(codeModel);
         codeTable.setFocusable(false);
@@ -87,12 +88,13 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
         codeTable.getTableHeader().setReorderingAllowed(false);
         codeTable.setShowHorizontalLines(true);
         codeTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
-        codeModel.addColumn(inst_header_text);
+        codeModel.addColumn(instHeaderText);
         TableColumnModel tcm = codeTable.getColumnModel();
-        tcm.getColumn(0).setMaxWidth(inst_name_max_column_width);
-        tcm.getColumn(0).setMinWidth(inst_name_max_column_width);
+        tcm.getColumn(0).setMaxWidth(instructionNameMaxColWidth);
+        tcm.getColumn(0).setMinWidth(instructionNameMaxColWidth);
         codeScrollPane = new JScrollPane(codeTable);
-        codeScrollPane.setPreferredSize(new Dimension(tcm.getColumn(0).getMaxWidth(), codeScrollPane.getPreferredSize().height));
+        codeScrollPane.setPreferredSize(new Dimension(tcm.getColumn(0).getMaxWidth(),
+                codeScrollPane.getPreferredSize().height));
         codeScrollBar = codeScrollPane.getVerticalScrollBar();
         codeScrollBar.addAdjustmentListener(new AdjustmentListener()
         {
@@ -112,12 +114,13 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
         addrTable.getTableHeader().setReorderingAllowed(false);
         addrTable.setShowHorizontalLines(true);
         addrTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
-        addrModel.addColumn(addr_header_text);
+        addrModel.addColumn(addrHeaderText);
         TableColumnModel tcm2 = addrTable.getColumnModel();
-        tcm2.getColumn(0).setMaxWidth(inst_name_max_column_width);
-        tcm2.getColumn(0).setMinWidth(inst_name_max_column_width);
+        tcm2.getColumn(0).setMaxWidth(instructionNameMaxColWidth);
+        tcm2.getColumn(0).setMinWidth(instructionNameMaxColWidth);
         addrScrollPane = new JScrollPane(addrTable);
-        addrScrollPane.setPreferredSize(new Dimension(tcm2.getColumn(0).getMaxWidth(), addrScrollPane.getPreferredSize().height));
+        addrScrollPane.setPreferredSize(new Dimension(tcm2.getColumn(0).getMaxWidth(),
+                addrScrollPane.getPreferredSize().height));
         addrScrollBar = addrScrollPane.getVerticalScrollBar();
         addrScrollBar.addAdjustmentListener(new AdjustmentListener()
         {
@@ -161,7 +164,7 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
 
         });
 
-        // scrolling synchronously causes view violations 
+        // scrolling synchronously causes view violations
         // requires a more complex/sophisticated approach
 //        clockCycleScrollBarHorizontal = clockCycleScrollPane.getHorizontalScrollBar();
         /*  clockCycleScrollBarHorizontal.addAdjustmentListener(new AdjustmentListener()
@@ -170,11 +173,12 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
          public void adjustmentValueChanged(AdjustmentEvent e)
          {
          clockCycleScrollBarVertical.setValue(e.getValue());
-                
+
          }
 
          });*/
-        clockCycleScrollPane.setPreferredSize(new Dimension(3 * block, clockCycleScrollPane.getPreferredSize().height));
+        clockCycleScrollPane.setPreferredSize(new Dimension(3 * block,
+                clockCycleScrollPane.getPreferredSize().height));
         return clockCycleScrollPane;
 
     }
@@ -188,48 +192,32 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
         codeModel.setRowCount(0);
         model.setColumnCount(0);
         model.setRowCount(0);
-        Iterator<uint32> codeIterator = ClockCycleLog.code.iterator();
         DLXAssembler asm = new DLXAssembler();
+
         int i = 0;
-        while (codeIterator.hasNext())
+        for (uint32 addr : ClockCycleLog.code)
         {
-            uint32 addr = codeIterator.next();
             try
             {
-
                 uint32 inst = openDLXSim.getPipeline().getInstructionMemory().read_u32(addr);
                 String instStr = asm.Instr2Str(inst.getValue());
-                String[] instrAddrText =
-                {
-                    addr.getHex()
-                };
-
-                String[] instrText =
-                {
-                    instStr
-                };
-                addrModel.addRow(instrAddrText);
-                codeModel.addRow(instrText);
+                addrModel.addRow(new String[] { addr.getHex() });
+                codeModel.addRow(new String[] { instStr });
                 model.addColumn(i);
-                String cycleValue[] =
-                {
-                    ""
-                };
-                model.addRow(cycleValue);
-                HashMap h = ClockCycleLog.log.get(i);
-                Iterator<uint32> setIterator = h.keySet().iterator();
-                while (setIterator.hasNext())
-                {
-                    uint32 checkAddr = setIterator.next();
+                model.addRow(new String[] { "" });
 
-                    ArrayList forbidden = new ArrayList();
+                final HashMap<uint32, String> h = ClockCycleLog.log.get(i);
+                for (uint32 checkAddr : h.keySet())
+                {
+                    final ArrayList<uint32> forbidden = new ArrayList<>();
                     for (int k = addrModel.getRowCount() - 1; k >= 0; --k)
                     {
-                        if (addrModel.getValueAt(k, 0).equals(checkAddr.getHex()) && !forbidden.contains(checkAddr) && !instStr.contains("bubble"))
+                        if (addrModel.getValueAt(k, 0).equals(checkAddr.getHex())
+                                && !forbidden.contains(checkAddr)
+                                && !instStr.contains("bubble"))
                         {
                             model.setValueAt(h.get(checkAddr), k, i);
                             forbidden.add(checkAddr);
-
                         }
                     }
                 }
@@ -251,7 +239,7 @@ public final class ClockCycleFrame extends OpenDLXSimInternalFrame implements GU
         table.scrollRectToVisible(table.getCellRect(table.getRowCount() - 1, table.getColumnCount() - 1, true));
         codeTable.scrollRectToVisible(codeTable.getCellRect(table.getRowCount() - 1, 0, true));
         addrTable.scrollRectToVisible(addrTable.getCellRect(addrTable.getRowCount() - 1, 0, true));
-        
+
     }
 
     @Override

--- a/src/openDLX/gui/internalframes/concreteframes/CodeFrame.java
+++ b/src/openDLX/gui/internalframes/concreteframes/CodeFrame.java
@@ -22,20 +22,23 @@
 package openDLX.gui.internalframes.concreteframes;
 
 import java.awt.BorderLayout;
+
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.TableModel;
-import openDLX.gui.MainFrame;
-import openDLX.gui.internalframes.factories.tableFactories.CodeTableFactory;
-import openDLX.gui.internalframes.OpenDLXSimInternalFrame;
-import openDLX.gui.internalframes.util.TableSizeCalculator;
+
 import openDLX.OpenDLXSimulator;
+import openDLX.PipelineContainer;
+import openDLX.gui.MainFrame;
+import openDLX.gui.internalframes.OpenDLXSimInternalFrame;
+import openDLX.gui.internalframes.factories.tableFactories.CodeTableFactory;
+import openDLX.gui.internalframes.util.TableSizeCalculator;
 
 @SuppressWarnings("serial")
 public final class CodeFrame extends OpenDLXSimInternalFrame
 {
 
-    private OpenDLXSimulator openDLXSim;
+    private final OpenDLXSimulator openDLXSim;
     private JTable codeTable;
     private String IFValue = "";
     private String IDValue = "";
@@ -46,55 +49,43 @@ public final class CodeFrame extends OpenDLXSimInternalFrame
     public CodeFrame(String title)
     {
         super(title, false);
-        this.openDLXSim = MainFrame.getInstance().getOpenDLXSim();
+        openDLXSim = MainFrame.getInstance().getOpenDLXSim();
         initialize();
     }
 
     @Override
     public void update()
     {
-        IFValue = openDLXSim.getPipeline().getFetchDecodeLatch().element().getPc().getHex();
-        IDValue = openDLXSim.getPipeline().getDecodeExecuteLatch().element().getPc().getHex();
-        EXValue = openDLXSim.getPipeline().getExecuteMemoryLatch().element().getPc().getHex();
-        MEMValue = openDLXSim.getPipeline().getMemoryWriteBackLatch().element().getPc().getHex();
-        WBValue = openDLXSim.getPipeline().getWriteBackLatch().element().getPc().getHex();
+        final PipelineContainer pipeline = openDLXSim.getPipeline();
+        IFValue = pipeline.getFetchDecodeLatch().element().getPc().getHex();
+        IDValue = pipeline.getDecodeExecuteLatch().element().getPc().getHex();
+        EXValue = pipeline.getExecuteMemoryLatch().element().getPc().getHex();
+        MEMValue = pipeline.getMemoryWriteBackLatch().element().getPc().getHex();
+        WBValue = pipeline.getWriteBackLatch().element().getPc().getHex();
 
         TableModel model = codeTable.getModel();
         for (int row = 0; row < model.getRowCount(); ++row)
         {
             String addr = model.getValueAt(row, 0).toString().substring(0, 10);
 
-
             if (addr.contains(IFValue))
             {
-                model.setValueAt(addr + "  " + "IF", row, 0);
-                if (codeTable.getParent() != null)
-                {
-                    // move IF row into focus - i.e. scroll to IF-row
-                    codeTable.scrollRectToVisible(codeTable.getCellRect(row, 0, true));
+                addr += "  " + "IF";
 
-                }
+                // move IF row into focus - i.e. scroll to IF-row
+                if (codeTable.getParent() != null)
+                    codeTable.scrollRectToVisible(codeTable.getCellRect(row, 0, true));
             }
             else if (addr.contains(IDValue))
-            {
-                model.setValueAt(addr + "  " + "ID", row, 0);
-            }
+                addr += "  " + "ID";
             else if (addr.contains(EXValue))
-            {
-                model.setValueAt(addr + "  " + "EX", row, 0);
-            }
+                addr += "  " + "EX";
             else if (addr.contains(MEMValue))
-            {
-                model.setValueAt(addr + "  " + "MEM", row, 0);
-            }
+                addr += "  " + "MEM";
             else if (addr.contains(WBValue))
-            {
-                model.setValueAt(addr + "  " + "WB", row, 0);
-            }
-            else
-            {
-                model.setValueAt(model.getValueAt(row, 0).toString().substring(0, 10), row, 0);
-            }
+                addr += "  " + "WB";
+
+            model.setValueAt(addr, row, 0);
         }
     }
 
@@ -102,12 +93,13 @@ public final class CodeFrame extends OpenDLXSimInternalFrame
     protected void initialize()
     {
         super.initialize();
-        //make the scrollpane 
+        //make the scrollpane
         codeTable = new CodeTableFactory(openDLXSim).createTable();
         JScrollPane scrollpane = new JScrollPane(codeTable);
         scrollpane.setFocusable(false);
         codeTable.setFillsViewportHeight(true);
-        TableSizeCalculator.setDefaultMaxTableSize(scrollpane, codeTable, TableSizeCalculator.SET_SIZE_WIDTH);
+        TableSizeCalculator.setDefaultMaxTableSize(scrollpane, codeTable,
+                TableSizeCalculator.SET_SIZE_WIDTH);
         //config internal frame
         setLayout(new BorderLayout());
         add(scrollpane, BorderLayout.CENTER);

--- a/src/openDLX/gui/internalframes/concreteframes/LogFrame.java
+++ b/src/openDLX/gui/internalframes/concreteframes/LogFrame.java
@@ -23,14 +23,15 @@ package openDLX.gui.internalframes.concreteframes;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.util.Iterator;
+
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+
 import openDLX.gui.MainFrame;
+import openDLX.gui.internalframes.OpenDLXSimInternalFrame;
 import openDLX.gui.internalframes.renderer.LogFrameTableCellRenderer;
 import openDLX.gui.internalframes.util.LogReader;
-import openDLX.gui.internalframes.OpenDLXSimInternalFrame;
 import openDLX.gui.internalframes.util.NotSelectableTableModel;
 
 @SuppressWarnings("serial")
@@ -41,10 +42,8 @@ public final class LogFrame extends OpenDLXSimInternalFrame
     private JTable infoTable;
     private NotSelectableTableModel model;
     private JScrollPane scrollpane;
-    //default size values
-    private Dimension d = new Dimension(300, 200);
     //data
-    private MainFrame mf;
+    private final MainFrame mf;
     private LogReader logReader;
     private String logFileAddr;
 
@@ -62,7 +61,6 @@ public final class LogFrame extends OpenDLXSimInternalFrame
         {
             String err = "Reading log file failed -  " + e.toString();
             JOptionPane.showMessageDialog(mf, err);
-
         }
     }
 
@@ -71,27 +69,14 @@ public final class LogFrame extends OpenDLXSimInternalFrame
     {
         if (logFileAddr != null && logReader != null)
         {
-
             logReader.update();
-            Iterator<String> it = logReader.getLog().iterator();
-            while (it.hasNext())
-            {
-                String[] help =
-                {
-                    it.next().toString()
-                };
-                model.addRow(help);
-            }
-
+            model.addRow(logReader.getLog().toArray(new String[]{}));
 
             logReader.getLog().clear();
 
             if (scrollpane != null)
-            {
-
-                infoTable.scrollRectToVisible(infoTable.getCellRect(infoTable.getRowCount() - 1, 0, true));
-
-            }
+                infoTable.scrollRectToVisible(infoTable.getCellRect(
+                        infoTable.getRowCount() - 1, 0, true));
         }
     }
 
@@ -116,7 +101,7 @@ public final class LogFrame extends OpenDLXSimInternalFrame
         scrollpane = new JScrollPane(infoTable);
         scrollpane.setFocusable(false);
         add(scrollpane, BorderLayout.CENTER);
-        setSize(d);
+        setSize(new Dimension(300, 200));
         setVisible(true);
     }
 

--- a/src/openDLX/gui/internalframes/concreteframes/MemoryFrame.java
+++ b/src/openDLX/gui/internalframes/concreteframes/MemoryFrame.java
@@ -37,6 +37,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.table.TableModel;
+
 import openDLX.asm.Labels;
 import openDLX.datatypes.uint32;
 import openDLX.exception.MemoryException;
@@ -68,14 +69,13 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
         super(name, false);
         this.mf = mf;
         initialize();
-
     }
 
     @Override
     public void update()
     {
         TableModel model = memoryTable.getModel();
-        //get start-addr = first address in the memory table 
+        //get start-addr = first address in the memory table
         if (model.getColumnCount() > 0)
         {
             String startAddrString = model.getValueAt(0, 0).toString();
@@ -84,14 +84,13 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
             {
                 for (int i = 0; i < model.getRowCount(); ++i)
                 {
-                	if(Preference.displayMemoryAsHex())
-                	{
-                		model.setValueAt(MainFrame.getInstance().getOpenDLXSim().getPipeline().getMainMemory().read_u32(new uint32(Integer.parseInt(startAddrString.substring(2), 16) + i * 4)).getHex(), i, 1);
-                	}
-                	else
-                	{
-                		model.setValueAt(MainFrame.getInstance().getOpenDLXSim().getPipeline().getMainMemory().read_u32(new uint32(Integer.parseInt(startAddrString.substring(2), 16) + i * 4)).getValue(), i, 1);
-                	}
+                    final uint32 uint_val = MainFrame.getInstance().getOpenDLXSim().getPipeline().getMainMemory().read_u32(new uint32(Integer.parseInt(startAddrString.substring(2), 16) + i * 4));
+                    final Object value;
+                    if (Preference.displayMemoryAsHex())
+                        value = uint_val.getHex();
+                    else
+                        value = uint_val.getValue();
+                    model.setValueAt(value, i, 1);
                 }
             }
             catch (MemoryException e)
@@ -113,7 +112,7 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
         TableSizeCalculator.setDefaultMaxTableSize(scrollpane, memoryTable, TableSizeCalculator.SET_SIZE_WIDTH);
         add(scrollpane, BorderLayout.CENTER);
 
-        //input 
+        //input
         JPanel inputPanel = new JPanel();
         addrLabel = new JLabel("start addr");
         inputPanel.add(addrLabel);
@@ -150,24 +149,19 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
     @Override
     public void actionPerformed(ActionEvent e)
     {
-
-
         try
         {
             Integer value = ValueInput.getValueSilent(addrInput.getText());
             if (value != null)
-            {
                 startAddr = value;
-            }
+
             value = ValueInput.getValueSilent(rowInput.getText());
             if (value != null)
-            {
                 rows = value;
-            }
+
             clean();
             InternalFrameFactory.getInstance().createMemoryFrame(mf);
-            CommandLoadFrameConfigurationSysLevel c10 = new CommandLoadFrameConfigurationSysLevel(mf);
-            c10.execute();
+            new CommandLoadFrameConfigurationSysLevel(mf).execute();
         }
         catch (Exception ex)
         {
@@ -179,36 +173,29 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
                     startAddr = (Integer) Labels.labels.get(addrInput.getText());
                     clean();
                     InternalFrameFactory.getInstance().createMemoryFrame(mf);
-                    CommandLoadFrameConfigurationSysLevel c10 = new CommandLoadFrameConfigurationSysLevel(mf);
-                    c10.execute();
+                    new CommandLoadFrameConfigurationSysLevel(mf).execute();
                     error = false;
                 }
             }
+
             if (error)
-            {
-                JOptionPane.showMessageDialog(this, "for input only hex (0x..) address, decimal address or label (e.g. \"main\") allowed");
-            }
-
+                JOptionPane.showMessageDialog(this, "for input only hex (0x..) " +
+                        "address, decimal address or label (e.g. \"main\") allowed");
         }
-
     }
 
     @Override
     public void keyTyped(KeyEvent e)
     {
         if (e.getKeyCode() == KeyEvent.VK_ENTER)
-        {
             reload.doClick();
-        }
     }
 
     @Override
     public void keyPressed(KeyEvent e)
     {
         if (e.getKeyCode() == KeyEvent.VK_ENTER)
-        {
             reload.doClick();
-        }
     }
 
     @Override

--- a/src/openDLX/gui/internalframes/concreteframes/RegisterFrame.java
+++ b/src/openDLX/gui/internalframes/concreteframes/RegisterFrame.java
@@ -22,7 +22,10 @@
 package openDLX.gui.internalframes.concreteframes;
 
 import java.awt.BorderLayout;
-import javax.swing.*;
+
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+
 import openDLX.RegisterSet;
 import openDLX.datatypes.ArchCfg;
 import openDLX.datatypes.uint8;
@@ -49,29 +52,28 @@ public final class RegisterFrame extends OpenDLXSimInternalFrame
     @Override
     public void update()
     {
-    	for (int i = 0; i < ArchCfg.getRegisterCount(); ++i)
-    	{
-    		if (Preference.displayRegistersAsHex())
-    		{
-    			registerTable.getModel().setValueAt(rs.read(new uint8(i)), i, 1);
-    		}
-    		else
-    		{
-    			registerTable.getModel().setValueAt(rs.read(new uint8(i)).getValue(), i, 1);
-    		}
-    	}
+        for (int i = 0; i < ArchCfg.getRegisterCount(); ++i)
+        {
+            final Object value;
+            if (Preference.displayRegistersAsHex())
+                value = rs.read(new uint8(i));
+            else
+                value = rs.read(new uint8(i)).getValue();
+            registerTable.getModel().setValueAt(value, i, 1);
+        }
     }
 
     @Override
     protected void initialize()
     {
         super.initialize();
-        //make the scrollpane 
+        //make the scrollpane
         registerTable = new RegisterTableFactory(rs).createTable();
         JScrollPane scrollpane = new JScrollPane(registerTable);
         scrollpane.setFocusable(false);
         registerTable.setFillsViewportHeight(true);
-        TableSizeCalculator.setDefaultMaxTableSize(scrollpane, registerTable, TableSizeCalculator.SET_SIZE_BOTH);
+        TableSizeCalculator.setDefaultMaxTableSize(scrollpane, registerTable,
+                TableSizeCalculator.SET_SIZE_BOTH);
         //config internal frame
         setLayout(new BorderLayout());
         add(scrollpane, BorderLayout.CENTER);

--- a/src/openDLX/gui/internalframes/factories/tableFactories/CodeTableFactory.java
+++ b/src/openDLX/gui/internalframes/factories/tableFactories/CodeTableFactory.java
@@ -21,15 +21,16 @@
  ******************************************************************************/
 package openDLX.gui.internalframes.factories.tableFactories;
 
-import openDLX.gui.MainFrame;
 import javax.swing.JTable;
 import javax.swing.table.TableColumnModel;
+
+import openDLX.OpenDLXSimulator;
 import openDLX.asm.DLXAssembler;
 import openDLX.datatypes.uint32;
 import openDLX.exception.MemoryException;
+import openDLX.gui.MainFrame;
 import openDLX.gui.internalframes.renderer.CodeFrameTableCellRenderer;
 import openDLX.gui.internalframes.util.NotSelectableTableModel;
-import openDLX.OpenDLXSimulator;
 
 public class CodeTableFactory extends TableFactory
 {
@@ -55,45 +56,37 @@ public class CodeTableFactory extends TableFactory
 
         //default max width values change here
         TableColumnModel tcm = table.getColumnModel();
-        int defaultWidht = 150;
-        tcm.getColumn(0).setMaxWidth(defaultWidht);
-        tcm.getColumn(1).setMaxWidth(defaultWidht);
-        tcm.getColumn(2).setMaxWidth(defaultWidht);
+        final int defaultWidth = 150;
+        tcm.getColumn(0).setMaxWidth(defaultWidth);
+        tcm.getColumn(1).setMaxWidth(defaultWidth);
+        tcm.getColumn(2).setMaxWidth(defaultWidth);
         table.setDefaultRenderer(Object.class, new CodeFrameTableCellRenderer());
 
-        //insert code 
+        //insert code
         int start;
         if (!openDLXSim.getConfig().containsKey("text_begin"))
-        {
             start = openDLXSim.getPipeline().getFetchStage().getPc().getValue();
-        }
         else
-        {
             start = stringToInt(openDLXSim.getConfig().getProperty("text_begin"));
-        }
 
         int end = openDLXSim.getSimCycles();
         if (!openDLXSim.getConfig().containsKey("text_end"))
-        {
             end = start + 4 * openDLXSim.getSimCycles();
-        }
         else
-        {
             end = stringToInt(openDLXSim.getConfig().getProperty("text_end"));
-        }
 
         DLXAssembler asm = new DLXAssembler();
         try
         {
             for (int i = start; i < end; i += 4)
             {
-                uint32 addr = new uint32(i);
-                uint32 inst = openDLXSim.getPipeline().getInstructionMemory().read_u32(new uint32(i));
-                String instStr = asm.Instr2Str(inst.getValue());
+                final uint32 inst = openDLXSim.getPipeline().getInstructionMemory().read_u32(new uint32(i));
 
                 model.addRow(new Object[]
                         {
-                            addr, inst, instStr
+                            new uint32(i),
+                            inst,
+                            asm.Instr2Str(inst.getValue())
                         });
             }
         }

--- a/src/openDLX/gui/internalframes/factories/tableFactories/RegisterTableFactory.java
+++ b/src/openDLX/gui/internalframes/factories/tableFactories/RegisterTableFactory.java
@@ -24,8 +24,10 @@ package openDLX.gui.internalframes.factories.tableFactories;
 import java.awt.Point;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+
 import javax.swing.JTable;
 import javax.swing.table.TableColumnModel;
+
 import openDLX.RegisterSet;
 import openDLX.datatypes.ArchCfg;
 import openDLX.datatypes.uint8;
@@ -53,20 +55,20 @@ public class RegisterTableFactory extends TableFactory
         model.addColumn("Register");
         model.addColumn("Values");
 
-		for (int i = 0; i < ArchCfg.getRegisterCount(); ++i)
-		{
-			if (Preference.displayRegistersAsHex())
-			{
-				model.addRow(new Object[] { ArchCfg.getRegisterDescription(i),
-						rs.read(new uint8(i)) });
-			} else
-			{
-				model.addRow(new Object[] { ArchCfg.getRegisterDescription(i),
-						rs.read(new uint8(i)).getValue() });
-			}
+        for (int i = 0; i < ArchCfg.getRegisterCount(); ++i)
+        {
+            final Object secondItem;
+            if (Preference.displayRegistersAsHex())
+                secondItem = rs.read(new uint8(i));
+            else
+                secondItem = rs.read(new uint8(i)).getValue();
+
+            model.addRow(new Object[] {
+                    ArchCfg.getRegisterDescription(i), secondItem
+            });
         }
 
-        //default max width values change here 
+        //default max width values change here
         TableColumnModel tcm = table.getColumnModel();
         tcm.getColumn(0).setMaxWidth(60);
         tcm.getColumn(1).setMaxWidth(150);
@@ -77,20 +79,15 @@ public class RegisterTableFactory extends TableFactory
             @Override
             public void mouseClicked(MouseEvent e)
             {
-
                 Point p = e.getPoint();
                 int row = table.rowAtPoint(p);
-                if (e.getClickCount() == 2)
-                {
-                    CommandChangeRegister c = new CommandChangeRegister(row);
-                    c.execute();
-                }
-            }
 
+                if (e.getClickCount() == 2)
+                    new CommandChangeRegister(row).execute();
+            }
         });
 
         return table;
-
     }
 
 }

--- a/src/openDLX/gui/internalframes/renderer/ChangeableFrameTableCellRenderer.java
+++ b/src/openDLX/gui/internalframes/renderer/ChangeableFrameTableCellRenderer.java
@@ -22,11 +22,13 @@
 package openDLX.gui.internalframes.renderer;
 
 import java.awt.Component;
+
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.border.Border;
 import javax.swing.table.TableCellRenderer;
+
 import openDLX.gui.GUI_CONST;
 import openDLX.gui.command.userLevel.CommandDisplayTooltips;
 
@@ -37,7 +39,6 @@ public class ChangeableFrameTableCellRenderer implements TableCellRenderer, GUI_
     public Component getTableCellRendererComponent(JTable table, Object value,
             boolean isSelected, boolean hasFocus, int row, int column)
     {
-
         //set defaults
         JLabel label = new JLabel(value.toString());
         label.setOpaque(true);
@@ -46,16 +47,10 @@ public class ChangeableFrameTableCellRenderer implements TableCellRenderer, GUI_
         label.setFont(table.getFont());
         label.setForeground(table.getForeground());
         label.setBackground(table.getBackground());
-        
-        if (CommandDisplayTooltips.isTooltipsEnabled())
-        {
-            label.setToolTipText("double click to change");
-        }
 
-    
+        if (CommandDisplayTooltips.isTooltipsEnabled())
+            label.setToolTipText("double click to change");
 
         return label;
-
     }
-
 }

--- a/src/openDLX/gui/internalframes/renderer/ClockCycleFrameTableCellRenderer.java
+++ b/src/openDLX/gui/internalframes/renderer/ClockCycleFrameTableCellRenderer.java
@@ -22,18 +22,21 @@
 package openDLX.gui.internalframes.renderer;
 
 import java.awt.Component;
+
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.border.Border;
 import javax.swing.table.TableCellRenderer;
+
 import openDLX.gui.GUI_CONST;
 
 public class ClockCycleFrameTableCellRenderer implements TableCellRenderer
 {
 
     @Override
-    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column)
+    public Component getTableCellRendererComponent(JTable table, Object value,
+            boolean isSelected, boolean hasFocus, int row, int column)
     {
         //set defaults
         JLabel label = new JLabel((String) value);
@@ -44,51 +47,25 @@ public class ClockCycleFrameTableCellRenderer implements TableCellRenderer
         label.setForeground(table.getForeground());
         label.setBackground(table.getBackground());
 
-        //FETCH
         if (label.getText() != null)
         {
+            //FETCH
             if (label.getText().contains(GUI_CONST.FETCH))
-            {
                 label.setBackground(GUI_CONST.IF_COLOR);
-            }
-        }
-        //DECODE 
-        if (label.getText() != null)
-        {
-            if (label.getText().contains(GUI_CONST.DECODE))
-            {
+            //DECODE
+            else if (label.getText().contains(GUI_CONST.DECODE))
                 label.setBackground(GUI_CONST.ID_COLOR);
-            }
-        }
-        //EXECUTE
-        if (label.getText() != null)
-        {
-            if (label.getText().contains(GUI_CONST.EXECUTE))
-            {
+            //EXECUTE
+            else if (label.getText().contains(GUI_CONST.EXECUTE))
                 label.setBackground(GUI_CONST.EX_COLOR);
-            }
-        }
-        //MEMORY
-        if (label.getText() != null)
-        {
-            if (label.getText().contains(GUI_CONST.MEMORY))
-            {
+            //MEMORY
+            else if (label.getText().contains(GUI_CONST.MEMORY))
                 label.setBackground(GUI_CONST.MEM_COLOR);
-            }
-        }
-        //WRITEBACK
-        if (label.getText() != null)
-        {
-            if (label.getText().contains(GUI_CONST.WRITEBACK))
-            {
+            //WRITEBACK
+            else if (label.getText().contains(GUI_CONST.WRITEBACK))
                 label.setBackground(GUI_CONST.WB_COLOR);
-            }
         }
-
-
 
         return label;
-
     }
-
 }

--- a/src/openDLX/gui/internalframes/renderer/CodeFrameTableCellRenderer.java
+++ b/src/openDLX/gui/internalframes/renderer/CodeFrameTableCellRenderer.java
@@ -22,11 +22,13 @@
 package openDLX.gui.internalframes.renderer;
 
 import java.awt.Component;
+
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.border.Border;
 import javax.swing.table.TableCellRenderer;
+
 import openDLX.asm.DLXAssembler;
 import openDLX.gui.GUI_CONST;
 import openDLX.gui.command.userLevel.CommandDisplayTooltips;
@@ -38,7 +40,6 @@ public final class CodeFrameTableCellRenderer implements TableCellRenderer, GUI_
     public Component getTableCellRendererComponent(JTable table, Object value,
             boolean isSelected, boolean hasFocus, int row, int column)
     {
-
         //set defaults
         JLabel label = new JLabel(value.toString());
         label.setOpaque(true);
@@ -47,47 +48,31 @@ public final class CodeFrameTableCellRenderer implements TableCellRenderer, GUI_
         label.setFont(table.getFont());
         label.setForeground(table.getForeground());
         label.setBackground(table.getBackground());
-        
+
         if (CommandDisplayTooltips.isTooltipsEnabled())
         {
             DLXAssembler dlx = new DLXAssembler();
-            label.setToolTipText(dlx.InstrDescription(table.getModel().getValueAt(row, 2).toString().split(" ")[0]));
+            label.setToolTipText(dlx.InstrDescription(
+                    table.getModel().getValueAt(row, 2).toString().split(" ")[0]));
         }
 
         //FETCH
         if (label.getText().contains(FETCH))
-        {
             label.setBackground(GUI_CONST.IF_COLOR);
-
-        }
-        //DECODE 
+        //DECODE
         else if (label.getText().contains(DECODE))
-        {
             label.setBackground(GUI_CONST.ID_COLOR);
-
-        }
         //EXECUTE
         else if (label.getText().contains(EXECUTE))
-        {
             label.setBackground(GUI_CONST.EX_COLOR);
-
-        }
         //MEMORY
         else if (label.getText().contains(MEMORY))
-        {
             label.setBackground(GUI_CONST.MEM_COLOR);
-
-        }
         //WRITEBACK
         else if (label.getText().contains(WRITEBACK))
-        {
             label.setBackground(GUI_CONST.WB_COLOR);
 
-        }
-
-
         return label;
-
     }
 
 }

--- a/src/openDLX/gui/internalframes/renderer/LogFrameTableCellRenderer.java
+++ b/src/openDLX/gui/internalframes/renderer/LogFrameTableCellRenderer.java
@@ -23,11 +23,13 @@ package openDLX.gui.internalframes.renderer;
 
 import java.awt.Color;
 import java.awt.Component;
+
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.border.Border;
 import javax.swing.table.TableCellRenderer;
+
 import openDLX.gui.internalframes.util.LogReader;
 
 public class LogFrameTableCellRenderer implements TableCellRenderer
@@ -37,13 +39,11 @@ public class LogFrameTableCellRenderer implements TableCellRenderer
     private final Color infoColor = Color.BLUE;
     private final Color warnColor = Color.ORANGE;
     private final Color errorColor = Color.RED;
-    
-    
+
     @Override
     public Component getTableCellRendererComponent(JTable table, Object value,
             boolean isSelected, boolean hasFocus, int row, int column)
     {
-
         //set defaults
         JLabel label = new JLabel(value.toString());
         label.setOpaque(true);
@@ -52,31 +52,23 @@ public class LogFrameTableCellRenderer implements TableCellRenderer
         label.setFont(table.getFont());
         label.setForeground(table.getForeground());
         label.setBackground(table.getBackground());
-        
-        String help = table.getModel().getValueAt(row, column).toString();       
-      
+
+        String help = table.getModel().getValueAt(row, column).toString();
+
             //DEBUG
             if (help.contains(LogReader.DEBUG_STRING))
-            {
                 label.setForeground(debugColor);
-            }
             //INFO
             else  if (help.contains(LogReader.INFO_STRING))
-            {
                 label.setForeground(infoColor);
-            }
             //WARN
             else  if (help.contains(LogReader.WARN_STRING))
-            {
                 label.setForeground(warnColor);
-            }
             //ERROR
             else  if (help.contains(LogReader.ERROR_STRING))
-            {
                 label.setForeground(errorColor);
-            }
-        
+
         return label;
     }
-    
+
 }

--- a/src/openDLX/gui/internalframes/util/TableSizeCalculator.java
+++ b/src/openDLX/gui/internalframes/util/TableSizeCalculator.java
@@ -22,49 +22,42 @@
 package openDLX.gui.internalframes.util;
 
 import java.awt.Dimension;
-import javax.swing.*;
-import javax.swing.table.*;
+
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.TableColumnModel;
 
 public class TableSizeCalculator
 {
-
-    static final public int SET_SIZE_HEIGHT = 0;
-    static final public int SET_SIZE_WIDTH = 1;
-    static final public int SET_SIZE_BOTH = 2;
+    public static final int SET_SIZE_HEIGHT = 0;
+    public static final int SET_SIZE_WIDTH = 1;
+    public static final int SET_SIZE_BOTH = 2;
 
     public static void setDefaultMaxTableSize(JScrollPane scrollpane, JTable table, int type)
     {
-
         int width = 0;
-        int height = 0;
-        TableModel tm = table.getModel();
-        TableColumnModel cm = table.getColumnModel();
+        final int height = (table.getRowCount() + 2) * table.getRowHeight();
 
-        for (int i = 0; i < tm.getColumnCount(); ++i)
+        final int colCount = table.getModel().getColumnCount();
+        final TableColumnModel cm = table.getColumnModel();
+
+        for (int i = 0; i < colCount; ++i)
         {
             width += cm.getColumn(i).getMaxWidth();
         }
 
-        height = (table.getRowCount() + 2) * table.getRowHeight();
-
         switch (type)
         {
             case SET_SIZE_HEIGHT:
-                scrollpane.setPreferredSize(new Dimension(scrollpane.getPreferredSize().width, height));
+                scrollpane.setPreferredSize(new Dimension(
+                        scrollpane.getPreferredSize().width, height));
                 break;
             case SET_SIZE_WIDTH:
-                scrollpane.setPreferredSize(new Dimension(width, scrollpane.getPreferredSize().height));
+                scrollpane.setPreferredSize(new Dimension(width,
+                        scrollpane.getPreferredSize().height));
                 break;
             default:
                 scrollpane.setPreferredSize(new Dimension(width, height));
-
-
-
-
         }
-
-
-
     }
-
 }

--- a/src/openDLX/gui/internalframes/util/ValueInput.java
+++ b/src/openDLX/gui/internalframes/util/ValueInput.java
@@ -28,34 +28,17 @@ public class ValueInput
 
     public static Integer getValue(String message, Object defaultValue) throws NumberFormatException
     {
-
         String valueString = JOptionPane.showInputDialog(message, defaultValue);
         return getValueSilent(valueString);
-
     }
 
     public static Integer getValueSilent(String valueString)
     {
-
-        if (valueString != null)
-        {
-
-            if (valueString.contains("0x"))
-            {
-                StringBuilder sb = new StringBuilder(valueString);
-
-                return Integer.parseInt(sb.substring(2), 16);
-
-
-            }
-            else
-            {
-                return Integer.parseInt(valueString);
-            }
-
-
-        }
-        return null;
+        if (valueString == null)
+            return null;
+        else if (valueString.contains("0x"))
+            return Integer.parseInt(valueString.substring(2), 16);
+        else
+            return Integer.parseInt(valueString);
     }
-
 }

--- a/src/openDLX/util/ClockCycleLog.java
+++ b/src/openDLX/util/ClockCycleLog.java
@@ -23,13 +23,11 @@ package openDLX.util;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+
 import openDLX.datatypes.uint32;
 
 public class ClockCycleLog
 {
-
-    public static ArrayList<HashMap> log = new ArrayList<>();
+    public static ArrayList<HashMap<uint32, String>> log = new ArrayList<>();
     public static ArrayList<uint32> code = new ArrayList<>();
-
-    
 }


### PR DESCRIPTION
This further improves code readability and cleans up the code.
To not make review impossible by creating a single huge commit, I'm committing
this now and will go on cleaning up afterward.

The improvements and fixes include but are not limited to:
- use extended `for` loops if applicable (instead of classic `for` loops or
  object iterators if unnecessary)
- remove unnecessary curly braces if that improves readability (e.g. on short
  one-instruction loops or `if`-statements
- typize generic classes if possible (also gets rid of warnings)
- inline single-use variables if it improves readability
- reduce code duplication by introducing variables
- add `final` modifier to fields and variables if appropriate
- rename identifiers to comply with javaCamelCase convention (instead of
  underscores)
- move certain listener/action implementations into anonymous inner classes in
  order to place them close to the item they belong to
- use `==` operator instead of `equals()` method if checking a reference
- call static methods in a static way (e.g. use `MainFrame` instead of `mf`)
- add `else` to `if`-statement-chain if cases are mutually exclusive
- add line breaks to very long statements
- replace all tabs by spaces
- remove trailing whitespace
- remove unnecessary blank lines

As usual, I recommend reviewing and testing these changes, as I might easily have overlooked something that change more than cosmetics.

If there are single changes that ought to be reverted or changed further, please highlight and mention them (e.g. line comments) and I will append this PR.
